### PR TITLE
Display all posts, regardless of the language tag

### DIFF
--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -53,7 +53,7 @@ def get_index_context(page_param, articles, total_pages):
 
 def get_article_context(article):
     """
-    Build the content for the an article page
+    Build the content for the article page
     :param article: Article to create context for
     """
 

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -51,7 +51,7 @@ def article_redirect(request, slug, year=None, month=None, day=None):
 
 def article(request, slug):
     try:
-        article = api.get_article(slug, tags_id)
+        article = api.get_article(slug)
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)
 

--- a/canonicalwebteam/blog/flask/views.py
+++ b/canonicalwebteam/blog/flask/views.py
@@ -56,7 +56,7 @@ def build_blueprint(blog_title, tags_id, tag_name, excluded_tags=[]):
     @blog.route("/<slug>")
     def article(slug):
         try:
-            articles = api.get_article(slug, tags_id)
+            articles = api.get_article(slug)
         except Exception:
             return flask.abort(502)
 


### PR DESCRIPTION
## Done
Remove restriction to display only articles that have a specific `tag_id`, set in settings/blueprint

## QA
- Copy this new version (canonicalwebteam folder ) into an instance of https://github.com/canonical-web-and-design/cn.ubuntu.com . 
- remove the blog-module from that instances `requirements.txt`
- start the instance and make sure that clicking on related articles on an article page ( http://localhost:8010/blog/running-android-with-amazon-ec2-a1-instances-cn) works
