### PR TITLE
Only display related articles that have certain tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Install dependencies
           command: |
             apt install -yy python3-venv
-            pip3 install poetry
+            pip3 install poetry==0.12.11 # https://github.com/sdispater/poetry/issues/1060 can probably be unpinned when you read this.
             poetry install
       - run:
           name: Print env

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.4.0: Only display related articles who have the desired tags, change setting variable name for TAG_IDS
 1.3.5: Dont exclude article pages based on tag_ids
 1.3.4: Dynamically loads 3/4 articles for latest news
 1.3.2: Adds flask __init__.py to flask submodule

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -8,7 +8,7 @@ from canonicalwebteam.blog.common_view_logic import (
     get_article_context,
 )
 
-tags_id = settings.BLOG_CONFIG["TAGS_ID"]
+tag_ids = settings.BLOG_CONFIG["TAG_IDS"]
 excluded_tags = settings.BLOG_CONFIG["EXCLUDED_TAGS"]
 blog_title = settings.BLOG_CONFIG["BLOG_TITLE"]
 tag_name = settings.BLOG_CONFIG["TAG_NAME"]
@@ -19,7 +19,7 @@ def index(request):
 
     try:
         articles, total_pages = api.get_articles(
-            tags=tags_id, exclude=excluded_tags, page=page_param
+            tags=tag_ids, exclude=excluded_tags, page=page_param
         )
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)
@@ -51,13 +51,13 @@ def article_redirect(request, slug, year=None, month=None, day=None):
 
 def article(request, slug):
     try:
-        article = api.get_article(slug)
+        article = api.get_article(slug, tag_ids)
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)
 
     if not article:
         return HttpResponseNotFound("Article not found")
-    context = get_article_context(article)
+    context = get_article_context(article, tag_ids)
 
     return render(request, "blog/article.html", context)
 
@@ -66,7 +66,7 @@ def latest_news(request):
 
     try:
         latest_pinned_articles = api.get_articles(
-            tags=tags_id,
+            tags=tag_ids,
             exclude=excluded_tags,
             page=1,
             per_page=1,
@@ -75,7 +75,7 @@ def latest_news(request):
         # check if the number of returned articles is 0
         if len(latest_pinned_articles[0]) == 0:
             latest_articles = api.get_articles(
-                tags=tags_id,
+                tags=tag_ids,
                 exclude=excluded_tags,
                 page=1,
                 per_page=4,
@@ -83,7 +83,7 @@ def latest_news(request):
             )
         else:
             latest_articles = api.get_articles(
-                tags=tags_id,
+                tags=tag_ids,
                 exclude=excluded_tags,
                 page=1,
                 per_page=3,

--- a/canonicalwebteam/blog/flask/views.py
+++ b/canonicalwebteam/blog/flask/views.py
@@ -56,14 +56,14 @@ def build_blueprint(blog_title, tags_id, tag_name, excluded_tags=[]):
     @blog.route("/<slug>")
     def article(slug):
         try:
-            articles = api.get_article(slug)
+            articles = api.get_article(slug, tags_id)
         except Exception:
             return flask.abort(502)
 
         if not articles:
             flask.abort(404, "Article not found")
 
-        context = get_article_context(articles)
+        context = get_article_context(articles, tags_id)
 
         return flask.render_template("blog/article.html", **context)
 


### PR DESCRIPTION


## Done
- Only display related articles that have certain tags (extend api function with new parameter)
- Fix bug where groups where not loaded from cache

Fixes https://github.com/canonical-web-and-design/base-squad/issues/506
Fixes https://github.com/canonical-web-and-design/cn.ubuntu.com/issues/325
## QA
- Copy this new version (canonicalwebteam folder ) into an instance of https://github.com/canonical-web-and-design/cn.ubuntu.com . 
- remove the blog-module from that instances `requirements.txt`
- start the instance and go to  http://localhost:8010/blog/ubuntu-core-18-%e6%ad%a3%e5%bc%8f%e5%8f%91%e5%b8%83%ef%bc%9a%e7%94%a8%e4%ba%8e%e5%ae%89%e5%85%a8%e5%8f%af%e9%9d%a0%e7%9a%84%e7%89%a9%e8%81%94%e7%bd%91%e8%ae%be%e5%a4%87
- make sure that only chinese articles are displayed as related
