### PR TITLE
Adds news context generator function for group pages

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.5.2: Get correct article group on group page
 1.5.1: Ability to load articles for specific groups only, filtering them by category
 1.5.0: Adds featured posts to the index page, fixes parameter name on blueprint signature
 1.4.1: Correctly exclude articles based on tags set in settings

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -6,6 +6,7 @@ from canonicalwebteam.blog import logic
 from canonicalwebteam.blog.common_view_logic import (
     get_index_context,
     get_article_context,
+    get_group_page_context,
 )
 
 tag_ids = settings.BLOG_CONFIG["TAG_IDS"]
@@ -76,7 +77,7 @@ def group(request, slug, template_path):
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)
 
-    context = get_index_context(page_param, articles, total_pages)
+    context = get_group_page_context(page_param, articles, total_pages, group)
     context["title"] = blog_title
 
     return render(request, template_path, context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "1.5.1"
+version = "1.5.2"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 


### PR DESCRIPTION
The main group on articles was incorrect on group pages.
The initial plan was to fix this on the frontend.
After some reflection on the design, it became clear that implementing this on the backend is the cleaner solution

## QA
- Use https://github.com/canonical-web-and-design/www.ubuntu.com and replace `canonicalwebteam.blog==1.5.1` with `git+https://github.com/b-m-f/blog-extension@add-correct-group-to-articles-for-group-pages#egg=canonicalwebteam.blog` in `requirements.txt`
- `./run` the site
- head to `localhost;8001/blog/internet-of-things` and verify that all articles are displayed with that group on the article card