### PR TITLE
Add archives

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.5.4: Adds archives Endpoint for Django
 1.5.3: Adds current category object to the page context for filtering
 1.5.2: Get correct article group on group page
 1.5.1: Ability to load articles for specific groups only, filtering them by category

--- a/canonicalwebteam/blog/django/urls.py
+++ b/canonicalwebteam/blog/django/urls.py
@@ -5,6 +5,7 @@ from canonicalwebteam.blog.django.views import (
     article,
     feed,
     latest_news,
+    archives,
 )
 
 
@@ -49,6 +50,7 @@ urlpatterns = [
     path(r"/<yyyy:year>/<str:slug>", article_redirect),
     path(r"/feed", feed),
     path(r"/latest-news", latest_news),
+    path(r"/archives", archives),
     path(r"/<str:slug>", article, name="article"),
     path(r"", index),
 ]

--- a/canonicalwebteam/blog/wordpress_api.py
+++ b/canonicalwebteam/blog/wordpress_api.py
@@ -26,6 +26,8 @@ def get_articles(
     categories=[],
     sticky="",
     groups=[],
+    after="",
+    before="",
 ):
     """
     Get articles from Wordpress api
@@ -37,6 +39,8 @@ def get_articles(
     :param category: Array of categories, which articles
         should be fetched for
     :param sticky: string 'true' or 'false' to only get featured articles
+    :param before: ISO8601 compliant date string to limit by date
+    :param after: ISO8601 compliant date string to limit by date
     """
     url = (
         f"{API_URL}/posts?per_page={per_page}"
@@ -49,6 +53,10 @@ def get_articles(
     )
     if sticky != "":
         url = url + f"&sticky={sticky}"
+    if before != "":
+        url = url + f"&before={before}"
+    if after != "":
+        url = url + f"&after={after}"
 
     response = api_session.get(url)
     total_pages = response.headers.get("X-WP-TotalPages")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "1.5.3"
+version = "1.5.4"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 

--- a/tests/test_wordpress_api.py
+++ b/tests/test_wordpress_api.py
@@ -1,5 +1,6 @@
 import unittest
 
+from datetime import timedelta, date
 from unittest.mock import patch
 from canonicalwebteam.blog import wordpress_api as api
 
@@ -199,5 +200,28 @@ class TestWordPressApi(unittest.TestCase):
             + "&categories="
             + "&exclude="
             + "&sticky=True"
+        )
+        self.assertEqual(article, (["hello_test"], 12))
+
+    @patch("canonicalwebteam.http.CachedSession.get")
+    def test_getting_articles_from_last_year(self, get):
+
+        get.return_value = MockResponse()
+
+        before = date(year=2007, month=12, day=5)
+        after = before - timedelta(days=365)
+        article = api.get_articles(after=after, before=before)
+        get.assert_called_once_with(
+            "https://admin.insights.ubuntu.com/"
+            + "wp-json/wp/v2/posts?"
+            + "per_page=12"
+            + "&tags="
+            + "&page=1"
+            + "&group="
+            + "&tags_exclude="
+            + "&categories="
+            + "&exclude="
+            + "&before=2007-12-05"
+            + "&after=2006-12-05"
         )
         self.assertEqual(article, (["hello_test"], 12))


### PR DESCRIPTION
Depends on https://github.com/canonical-web-and-design/canonicalwebteam.blog/pull/42

Adds archives endpoint

## QA
- Use https://github.com/canonical-web-and-design/www.ubuntu.com and replace `canonicalwebteam.blog==1.5.1` with `git+https://github.com/b-m-f/blog-extension@add-archives#egg=canonicalwebteam.blog` in `requirements.txt`
- `./run` the site
- head to `localhost;8001/blog/archives?year=2019&month=1` and verify that all articles displayed are from that month. Can be verified by checking against https://blog.ubuntu.com/archives?year=2019&month=1