### PR TITLE
Adds current category object to the page context for filtering

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.5.3: Adds current category object to the page context for filtering
 1.5.2: Get correct article group on group page
 1.5.1: Ability to load articles for specific groups only, filtering them by category
 1.5.0: Adds featured posts to the index page, fixes parameter name on blueprint signature

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -17,6 +17,7 @@ tag_name = settings.BLOG_CONFIG["TAG_NAME"]
 
 def index(request):
     page_param = request.GET.get("page", default="1")
+    category_param = request.GET.get("category", default="")
 
     try:
         if page_param == "1":
@@ -49,6 +50,7 @@ def index(request):
         page_param, articles, total_pages, featured_articles=featured_articles
     )
     context["title"] = blog_title
+    context["category"] = {"slug": category_param}
 
     return render(request, "blog/index.html", context)
 
@@ -79,6 +81,7 @@ def group(request, slug, template_path):
 
     context = get_group_page_context(page_param, articles, total_pages, group)
     context["title"] = blog_title
+    context["category"] = {"slug": category_param}
 
     return render(request, template_path, context)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "1.5.2"
+version = "1.5.3"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 


### PR DESCRIPTION
## Done
Adds current category to page contexts.

## QA
- Replace `canonicalwebteam.blog` with `https://github.com/b-m-f/canonicalwebteam.blog@add-category-to-context#egg=canonicalwebteam.blog` in your `requirements.txt`
- `./run`
- include `{{context}}` in any page template
- load the page of the template with `?category=articles` added to the URL
- make sure that `category.slug == articles` in the context