### PR TITLE
Adds upcoming endpoint and adds memory based caching for categories a…

### DIFF
--- a/canonicalwebteam/blog/django/urls.py
+++ b/canonicalwebteam/blog/django/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path, register_converter
 from canonicalwebteam.blog.django.views import (
-    index,
+    archives,
     article_redirect,
     article,
     feed,
+    index,
     latest_news,
-    archives,
+    upcoming,
 )
 
 
@@ -51,6 +52,7 @@ urlpatterns = [
     path(r"/<str:slug>", article, name="article"),
     path(r"/archives", archives),
     path(r"/feed", feed),
+    path(r"/upcoming", upcoming),
     path(r"/latest-news", latest_news),
     path(r"", index),
 ]

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -105,11 +105,33 @@ def topic(request, slug, template_path):
 
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)
-
     context = get_topic_page_context(page_param, articles, total_pages)
     context["title"] = blog_title
 
     return render(request, template_path, context)
+
+
+def upcoming(request):
+    try:
+        page_param = request.GET.get("page", default="1")
+
+        events = api.get_category_by_slug("events")
+        webinars = api.get_category_by_slug("webinars")
+
+        articles, total_pages = api.get_articles(
+            tags=tag_ids,
+            tags_exclude=excluded_tags,
+            page=page_param,
+            categories=[events["id"], webinars["id"]],
+        )
+
+    except Exception as e:
+        return HttpResponse("Error: " + e, status=502)
+
+    context = get_index_context(page_param, articles, total_pages)
+    context["title"] = blog_title
+
+    return render(request, "blog/upcoming.html", context)
 
 
 def archives(request, template_path="blog/archives.html"):

--- a/canonicalwebteam/blog/wordpress_api.py
+++ b/canonicalwebteam/blog/wordpress_api.py
@@ -121,7 +121,8 @@ def get_group_by_slug(slug):
     if not response.ok:
         return None
     try:
-        return process_response(response)[0]
+        groups_response = process_response(response)
+        return groups_response[0]
     except Exception:
         return None
 
@@ -130,8 +131,8 @@ def get_group_by_id(id):
     url = "".join([API_URL, "/group/", str(id)])
 
     response = api_session.get(url)
-
-    return process_response(response)
+    group = process_response(response)
+    return group
 
 
 def get_category_by_slug(slug):
@@ -142,7 +143,8 @@ def get_category_by_slug(slug):
     if not response.ok:
         return None
     try:
-        return process_response(response)[0]
+        category = process_response(response)
+        return category[0]
     except Exception:
         return None
 
@@ -151,22 +153,18 @@ def get_category_by_id(id):
     url = "".join([API_URL, "/categories/", str(id)])
 
     response = api_session.get(url)
-
-    return process_response(response)
+    category = process_response(response)
+    return category
 
 
 def get_tag_by_slug(slug):
-    if slug in tags:
-        return tags[slug]
-
     url = "".join([API_URL, "/tags/", f"?slug={slug}"])
 
     response = api_session.get(url)
 
     try:
-        tag = process_response(response)[0]
-        tags[slug] = tag
-        return tag
+        tag = process_response(response)
+        return tag[0]
     except Exception:
         return None
 


### PR DESCRIPTION
## Done
- adds `/upcoming` endpoint
- adds memory based caching for categories and groups

Fixes https://github.com/canonical-web-and-design/base-squad/issues/524

## QA
- Replace `canonicalwebteam.blog` with `https://github.com/b-m-f/canonicalwebteam.blog@add-upcomming-endpoint#egg=canonicalwebteam.blog` in your `requirements.txt`
- `./run`
- include `{{articles}}` in `blog/upcoming.html` template- go to https://localhost:8001/blog/upcoming and make sure that articles that are listed are the same as on https://blog.ubuntu.com/upcoming