### PR TITLE
Adds topic pages

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.5.5: Add topic pages
 1.5.4: Adds archives Endpoint for Django
 1.5.3: Adds current category object to the page context for filtering
 1.5.2: Get correct article group on group page

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ urlpatterns = [
     )
 ```
 
+#### Topic pages
+- Topic pages are optional as well and can be enabled by using the view `canonicalwebteam.blog.django.views.topic`. The view takes the topic slug to fetch data for and a template path to load the correct template from.
+
+**urls.py**
+```python
+path(
+		r"blog/topic/kubernetes",
+		topic,
+		{"slug": "kubernetes", "template_path": "blog/kubernetes.html"},
+		name="topic",
+),
+```
+
 ## Templates
 
 - You can now use the data from the blog. To display it the module expects templates at `blog/index.html`, `blog/article.html`, `blog/blog-card.html` . Inspiration can be found at https://github.com/canonical-websites/jp.ubuntu.com/tree/master/templates/blog.

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -102,6 +102,27 @@ def get_group_page_context(
     }
 
 
+def get_topic_page_context(page_param, articles, total_pages):
+    """
+    Build the content for a group page
+    :param page_param: String or int for index of the page to get
+    :param articles: Array of articles
+    :param articles: String of int of total amount of pages
+    """
+
+    transformed_articles = []
+    for article in articles:
+        transformed_articles.append(get_complete_article(article))
+
+    return {
+        "current_page": int(page_param),
+        "total_pages": int(total_pages),
+        "articles": transformed_articles,
+        "used_categories": category_cache,
+        "groups": group_cache,
+    }
+
+
 def get_article_context(article, related_tag_ids=[]):
     """
     Build the content for the article page

--- a/canonicalwebteam/blog/django/urls.py
+++ b/canonicalwebteam/blog/django/urls.py
@@ -48,9 +48,9 @@ urlpatterns = [
     path(r"/<yyyy:year>/<mm:month>/<dd:day>/<str:slug>", article_redirect),
     path(r"/<yyyy:year>/<mm:month>/<str:slug>", article_redirect),
     path(r"/<yyyy:year>/<str:slug>", article_redirect),
+    path(r"/<str:slug>", article, name="article"),
+    path(r"/archives", archives),
     path(r"/feed", feed),
     path(r"/latest-news", latest_news),
-    path(r"/archives", archives),
-    path(r"/<str:slug>", article, name="article"),
     path(r"", index),
 ]

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -7,6 +7,7 @@ from canonicalwebteam.blog.common_view_logic import (
     get_index_context,
     get_article_context,
     get_group_page_context,
+    get_topic_page_context,
 )
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -86,6 +87,27 @@ def group(request, slug, template_path):
     context = get_group_page_context(page_param, articles, total_pages, group)
     context["title"] = blog_title
     context["category"] = {"slug": category_param}
+
+    return render(request, template_path, context)
+
+
+def topic(request, slug, template_path):
+    try:
+        page_param = request.GET.get("page", default="1")
+
+        tag = api.get_tag_by_slug(slug)
+
+        articles, total_pages = api.get_articles(
+            tags=tag_ids + [tag["id"]],
+            tags_exclude=excluded_tags,
+            page=page_param,
+        )
+
+    except Exception as e:
+        return HttpResponse("Error: " + e, status=502)
+
+    context = get_topic_page_context(page_param, articles, total_pages)
+    context["title"] = blog_title
 
     return render(request, template_path, context)
 

--- a/canonicalwebteam/blog/wordpress_api.py
+++ b/canonicalwebteam/blog/wordpress_api.py
@@ -10,6 +10,8 @@ API_URL = os.getenv(
 
 api_session = CachedSession(fallback_cache_duration=3600)
 
+tags = {}
+
 
 def process_response(response):
     response.raise_for_status()
@@ -151,6 +153,22 @@ def get_category_by_id(id):
     response = api_session.get(url)
 
     return process_response(response)
+
+
+def get_tag_by_slug(slug):
+    if slug in tags:
+        return tags[slug]
+
+    url = "".join([API_URL, "/tags/", f"?slug={slug}"])
+
+    response = api_session.get(url)
+
+    try:
+        tag = process_response(response)[0]
+        tags[slug] = tag
+        return tag
+    except Exception:
+        return None
 
 
 def get_media(media_id):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "1.5.4"
+version = "1.5.5"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 


### PR DESCRIPTION
Adds topic endpoint

Fixes https://github.com/canonical-web-and-design/base-squad/issues/526

## QA
- Use https://github.com/canonical-web-and-design/www.ubuntu.com and replace `canonicalwebteam.blog==1.5.X` with `git+https://github.com/b-m-f/blog-extension@add-topic-pages#egg=canonicalwebteam.blog` in `requirements.txt`
- `./run` the site
- create a template at `blog/snappy.html` or copy the existing `blog/index.html` to that file
- add the following code to `urls.py`
```
    path(
        r"blog/topics/snappy",
        topic,
        {"slug": "snappy", "template_path": "blog/snappy.html"},
        name="topic",
    ),

```

- head to `localhost;8001/blog/topics/snappy` and verify that all articles displayed are from that month. Can be verified by checking against https://blog.ubuntu.com/topics/snappy