### PR TITLE
Add extra data to archives

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.5.6: Updates the information passed through to group pages and the archive template
 1.5.5: Add topic pages
 1.5.4: Adds archives Endpoint for Django
 1.5.3: Adds current category object to the page context for filtering

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -97,6 +97,7 @@ def get_group_page_context(
         "total_pages": int(total_pages),
         "articles": transformed_articles,
         "used_categories": category_cache,
+        "group": group,
         "groups": group_cache,
         "featured_articles": transformed_featured_articles,
     }

--- a/canonicalwebteam/blog/django/urls.py
+++ b/canonicalwebteam/blog/django/urls.py
@@ -48,9 +48,9 @@ urlpatterns = [
     path(r"/<yyyy:year>/<mm:month>/<dd:day>/<str:slug>", article_redirect),
     path(r"/<yyyy:year>/<mm:month>/<str:slug>", article_redirect),
     path(r"/<yyyy:year>/<str:slug>", article_redirect),
-    path(r"/<str:slug>", article, name="article"),
     path(r"/archives", archives),
     path(r"/feed", feed),
     path(r"/latest-news", latest_news),
+    path(r"/<str:slug>", article, name="article"),
     path(r"", index),
 ]

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -143,7 +143,7 @@ def archives(request, template_path="blog/archives.html"):
                 after = datetime(year=year, month=1, day=1)
                 before = datetime(year=year, month=12, day=31)
 
-        articles, total_pages = api.get_articles(
+        articles, total_pages, total_posts = api.get_articles(
             tags=tag_ids,
             tags_exclude=excluded_tags,
             page=page,
@@ -161,6 +161,7 @@ def archives(request, template_path="blog/archives.html"):
             context = get_index_context(page, articles, total_pages)
 
         context["title"] = blog_title
+        context["total_posts"] = total_posts
 
         return render(request, template_path, context)
 

--- a/canonicalwebteam/blog/wordpress_api.py
+++ b/canonicalwebteam/blog/wordpress_api.py
@@ -62,8 +62,9 @@ def get_articles(
 
     response = api_session.get(url)
     total_pages = response.headers.get("X-WP-TotalPages")
+    total_posts = response.headers.get("X-WP-Total")
 
-    return process_response(response), total_pages
+    return process_response(response), total_pages, total_posts
 
 
 def get_article(slug="", tags=[], tags_exclude=[]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "1.5.5"
+version = "1.5.6"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 

--- a/tests/test_wordpress_api.py
+++ b/tests/test_wordpress_api.py
@@ -86,7 +86,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&categories="
             + "&exclude="
         )
-        self.assertEqual(article, (["hello_test"], 12))
+        self.assertEqual(article, (["hello_test"], 12, None))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_getting_all_articles(self, get):
@@ -105,7 +105,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&categories="
             + "&exclude="
         )
-        self.assertEqual(article, (["hello_test"], 12))
+        self.assertEqual(article, (["hello_test"], 12, None))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_excluding_articles(self, get):
@@ -124,7 +124,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&categories="
             + "&exclude="
         )
-        self.assertEqual(article, (["hello_test"], 12))
+        self.assertEqual(article, (["hello_test"], 12, None))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_including_articles(self, get):
@@ -143,7 +143,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&categories="
             + "&exclude="
         )
-        self.assertEqual(article, (["hello_test"], 12))
+        self.assertEqual(article, (["hello_test"], 12, None))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_including_and_excluding_articles(self, get):
@@ -162,7 +162,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&categories="
             + "&exclude="
         )
-        self.assertEqual(article, (["hello_test"], 12))
+        self.assertEqual(article, (["hello_test"], 12, None))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_get_articles_for_category(self, get):
@@ -181,7 +181,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&categories=5678"
             + "&exclude="
         )
-        self.assertEqual(article, (["hello_test"], 12))
+        self.assertEqual(article, (["hello_test"], 12, None))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_getting_sticky_only(self, get):
@@ -201,7 +201,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&exclude="
             + "&sticky=True"
         )
-        self.assertEqual(article, (["hello_test"], 12))
+        self.assertEqual(article, (["hello_test"], 12, None))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_getting_articles_from_last_year(self, get):
@@ -224,4 +224,4 @@ class TestWordPressApi(unittest.TestCase):
             + "&before=2007-12-05"
             + "&after=2006-12-05"
         )
-        self.assertEqual(article, (["hello_test"], 12))
+        self.assertEqual(article, (["hello_test"], 12, None))


### PR DESCRIPTION
# Done
- add total amount of posts for a time period to the archive page
- only passes through the relevant group object into a group page

# QA
- Use https://github.com/canonical-web-and-design/www.ubuntu.com and replace `canonicalwebteam.blog==1.5.X` with `git+https://github.com/b-m-f/blog-extension@add-extra-data-to-archives#egg=canonicalwebteam.blog` in `requirements.txt`
- `./run` the site
- go to a archive group page. such as `/blog/archives?group=canonical-announcements`
- make sure that `{{total_posts}}` and `{{group}}` are available in the template