### PR TITLE
Add fix internal api for article metadata

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.5.9: Fix internal API function bug
 1.5.8: Adds author view
 1.5.7: Adds upcoming endpoint and view to Django
 1.5.6: Updates the information passed through to group pages and the archive template

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -189,7 +189,7 @@ def archives(request, template_path="blog/archives.html"):
                 after = datetime(year=year, month=1, day=1)
                 before = datetime(year=year, month=12, day=31)
 
-        articles, total_pages, total_posts = api.get_articles(
+        articles, metadata = api.get_articles_with_metadata(
             tags=tag_ids,
             tags_exclude=excluded_tags,
             page=page,
@@ -198,6 +198,9 @@ def archives(request, template_path="blog/archives.html"):
             after=after,
             before=before,
         )
+
+        total_pages = metadata["total_pages"]
+        total_posts = metadata["total_posts"]
 
         if group:
             context = get_group_page_context(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "1.5.8"
+version = "1.5.9"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 

--- a/tests/test_wordpress_api.py
+++ b/tests/test_wordpress_api.py
@@ -96,7 +96,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&exclude="
             + "&author="
         )
-        self.assertEqual(article, (["hello_test"], 12, None))
+        self.assertEqual(article, (["hello_test"], 12))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_getting_all_articles(self, get):
@@ -116,7 +116,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&exclude="
             + "&author="
         )
-        self.assertEqual(article, (["hello_test"], 12, None))
+        self.assertEqual(article, (["hello_test"], 12))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_excluding_articles(self, get):
@@ -136,7 +136,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&exclude="
             + "&author="
         )
-        self.assertEqual(article, (["hello_test"], 12, None))
+        self.assertEqual(article, (["hello_test"], 12))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_including_articles(self, get):
@@ -156,7 +156,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&exclude="
             + "&author="
         )
-        self.assertEqual(article, (["hello_test"], 12, None))
+        self.assertEqual(article, (["hello_test"], 12))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_including_and_excluding_articles(self, get):
@@ -176,7 +176,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&exclude="
             + "&author="
         )
-        self.assertEqual(article, (["hello_test"], 12, None))
+        self.assertEqual(article, (["hello_test"], 12))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_get_articles_for_category(self, get):
@@ -196,7 +196,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&exclude="
             + "&author="
         )
-        self.assertEqual(article, (["hello_test"], 12, None))
+        self.assertEqual(article, (["hello_test"], 12))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_getting_sticky_only(self, get):
@@ -217,7 +217,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&author="
             + "&sticky=True"
         )
-        self.assertEqual(article, (["hello_test"], 12, None))
+        self.assertEqual(article, (["hello_test"], 12))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_getting_articles_from_last_year(self, get):
@@ -241,7 +241,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&before=2007-12-05"
             + "&after=2006-12-05"
         )
-        self.assertEqual(article, (["hello_test"], 12, None))
+        self.assertEqual(article, (["hello_test"], 12))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_getting_articles_from_author(self, get):
@@ -261,7 +261,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&exclude="
             + "&author=1"
         )
-        self.assertEqual(article, (["hello_test"], 12, None))
+        self.assertEqual(article, (["hello_test"], 12))
 
     @patch("canonicalwebteam.http.CachedSession.get")
     def test_getting_articles_fail(self, get):


### PR DESCRIPTION
# Done
Fixes bug, where internal API function returns too much data.

## QA
- Use https://github.com/canonical-web-and-design/www.ubuntu.com and replace `canonicalwebteam.blog==1.5.X` with `git+https://github.com/b-m-f/blog-extension@fix-internal-api-for-article-metadata#egg=canonicalwebteam.blog` in `requirements.txt`
- `./run` the site
- make sure that `blog/achives`, `/blog` and `/blog/upcoming` are working normally 