### PR TITLE
Adds the next 3 upcoming events and webinars to the index page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.5.12: Add next 3 upcoming webinars and events to index
 1.5.11 Adds filtering by category to blog index
 1.5.10: Fix author search and pass more data to author template
 1.5.9: Fix internal API function bug

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -20,9 +20,10 @@ blog_title = settings.BLOG_CONFIG["BLOG_TITLE"]
 tag_name = settings.BLOG_CONFIG["TAG_NAME"]
 
 
-def index(request):
+def index(request, enable_upcoming=True):
     page_param = request.GET.get("page", default="1")
     category_param = request.GET.get("category", default="")
+    upcoming = []
 
     try:
         category_id = ""
@@ -47,6 +48,17 @@ def index(request):
                 page=page_param,
                 categories=[category_id],
             )
+            if enable_upcoming:
+                events = api.get_category_by_slug("events")
+                webinars = api.get_category_by_slug("webinars")
+                upcoming, _ = api.get_articles(
+                    tags=tag_ids,
+                    tags_exclude=excluded_tags,
+                    page=page_param,
+                    per_page=3,
+                    categories=[events["id"], webinars["id"]],
+                )
+
         else:
             articles, total_pages = api.get_articles(
                 tags=tag_ids,
@@ -64,6 +76,7 @@ def index(request):
     )
     context["title"] = blog_title
     context["category"] = {"slug": category_param}
+    context["upcoming"] = upcoming
 
     return render(request, "blog/index.html", context)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "1.5.11"
+version = "1.5.12"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 

--- a/tests/test_django_views.py
+++ b/tests/test_django_views.py
@@ -53,7 +53,7 @@ class TestDjangoViews(unittest.TestCase):
 
         django_client.get("/")
 
-        self.assertEqual(self.get_articles_patch.call_count, 2)
+        self.assertEqual(self.get_articles_patch.call_count, 3)
         self.get_index_context_patch.assert_called_once_with(
             "1", [mock_article], "1", featured_articles=[mock_article]
         )


### PR DESCRIPTION
# Done
- Adds the next 3 upcoming events and webinars to the index page

Fixes https://github.com/canonical-web-and-design/base-squad/issues/520

## QA
- Use https://github.com/canonical-web-and-design/www.ubuntu.com and replace `canonicalwebteam.blog==1.5.X` with `git+https://github.com/b-m-f/blog-extension@add-upcoming-to-index#egg=canonicalwebteam.blog` in `requirements.txt`
- `./run` the site
- add `{{upcoming}}` to `blog/index.html` and make sure that the data is present when going to `/blog`. It should be 3 entries