### PR TITLE
Pass more data to author template and fix author search

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.5.10: Fix author search and pass more data to author template
 1.5.9: Fix internal API function bug
 1.5.8: Adds author view
 1.5.7: Adds upcoming endpoint and view to Django

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -146,10 +146,7 @@ def author(request, username):
 
         context = {
             "title": blog_title,
-            "author": {
-                "image": author["avatar_urls"]["96"],
-                "name": author["name"],
-            },
+            "author": author,
             "latest_articles": articles,
         }
 

--- a/canonicalwebteam/blog/wordpress_api.py
+++ b/canonicalwebteam/blog/wordpress_api.py
@@ -238,7 +238,7 @@ def get_media(media_id):
 
 
 def get_user_by_username(username):
-    url = "".join([API_URL, "/users?search=", username])
+    url = "".join([API_URL, "/users?slug=", username])
     response = api_session.get(url)
 
     if not response.ok:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "1.5.9"
+version = "1.5.10"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 


### PR DESCRIPTION
## QA
- Use https://github.com/canonical-web-and-design/www.ubuntu.com and replace `canonicalwebteam.blog==1.5.X` with `git+https://github.com/b-m-f/blog-extension@add-more-data-to-author-endpoint#egg=canonicalwebteam.blog` in `requirements.txt`
- `./run` the site
- Go to `/blog/author/canonical` and make sure the posts match those from https://blog.ubuntu.com/author/canonical