### PR TITLE
Updates the url building to be more maintainable

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.5.11: Improves maintainability of wordpress API interface
 1.5.10: Fix author search and pass more data to author template
 1.5.9: Fix internal API function bug
 1.5.8: Adds author view

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "1.5.10"
+version = "1.5.11"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 


### PR DESCRIPTION
# Done
Fixes https://github.com/canonical-web-and-design/canonicalwebteam.blog/issues/15
**Blocked** until https://github.com/canonical-web-and-design/canonicalwebteam.blog/pull/55 is merged and rebased into this branch

[urllib.parse](https://docs.python.org/3/library/urllib.parse.html ) was considered, but has the problem of returning a named tuple, which can not easily be updated.
In order to avoid misusage of the module this approach was decided against.
Instead some refactoring work is done to make URL building more maintainable, by keeping it almost exclusively in one function.


