### PR TITLE
add category filter to blog index

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.5.11 Adds filtering by category to blog index
 1.5.10: Fix author search and pass more data to author template
 1.5.9: Fix internal API function bug
 1.5.8: Adds author view

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -24,6 +24,11 @@ def index(request):
     page_param = request.GET.get("page", default="1")
     category_param = request.GET.get("category", default="")
 
+    category_id = ""
+    if category_param != "":
+        category = api.get_category_by_slug(category_param)
+        category_id = category["id"]
+
     try:
         if page_param == "1":
             featured_articles, total_pages = api.get_articles(
@@ -32,6 +37,7 @@ def index(request):
                 page=page_param,
                 sticky="true",
                 per_page=3,
+                categories=[category_id]
             )
             featured_article_ids = [
                 article["id"] for article in featured_articles
@@ -41,10 +47,14 @@ def index(request):
                 tags_exclude=excluded_tags,
                 exclude=featured_article_ids,
                 page=page_param,
+                categories=[category_id]
             )
         else:
             articles, total_pages = api.get_articles(
-                tags=tag_ids, page=page_param, tags_exclude=excluded_tags
+                tags=tag_ids, 
+                page=page_param, 
+                tags_exclude=excluded_tags,
+                categories=[category_id]
             )
             featured_articles = []
 

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -24,12 +24,12 @@ def index(request):
     page_param = request.GET.get("page", default="1")
     category_param = request.GET.get("category", default="")
 
-    category_id = ""
-    if category_param != "":
-        category = api.get_category_by_slug(category_param)
-        category_id = category["id"]
-
     try:
+        category_id = ""
+        if category_param != "":
+            category = api.get_category_by_slug(category_param)
+            category_id = category["id"]
+            
         if page_param == "1":
             featured_articles, total_pages = api.get_articles(
                 tags=tag_ids,

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -38,7 +38,9 @@ def index(request):
                 sticky="true",
                 per_page=3,
             )
-            featured_article_ids = [article["id"] for article in featured_articles]
+            featured_article_ids = [
+                article["id"] for article in featured_articles
+            ]
             articles, total_pages = api.get_articles(
                 tags=tag_ids,
                 tags_exclude=excluded_tags,
@@ -105,7 +107,9 @@ def topic(request, slug, template_path):
         tag = api.get_tag_by_slug(slug)
 
         articles, total_pages = api.get_articles(
-            tags=tag_ids + [tag["id"]], tags_exclude=excluded_tags, page=page_param
+            tags=tag_ids + [tag["id"]],
+            tags_exclude=excluded_tags,
+            page=page_param,
         )
 
     except Exception as e:
@@ -143,10 +147,17 @@ def author(request, username):
     try:
         author = api.get_user_by_username(username)
         articles, total_pages = api.get_articles(
-            tags=tag_ids, tags_exclude=excluded_tags, per_page=5, author=author["id"]
+            tags=tag_ids,
+            tags_exclude=excluded_tags,
+            per_page=5,
+            author=author["id"],
         )
 
-        context = {"title": blog_title, "author": author, "latest_articles": articles}
+        context = {
+            "title": blog_title,
+            "author": author,
+            "latest_articles": articles,
+        }
 
         return render(request, "blog/author.html", context)
     except Exception as e:
@@ -198,7 +209,9 @@ def archives(request, template_path="blog/archives.html"):
         total_posts = metadata["total_posts"]
 
         if group:
-            context = get_group_page_context(page, articles, total_pages, group)
+            context = get_group_page_context(
+                page, articles, total_pages, group
+            )
         else:
             context = get_index_context(page, articles, total_pages)
 
@@ -247,16 +260,28 @@ def latest_news(request):
 
     try:
         latest_pinned_articles = api.get_articles(
-            tags=tag_ids, exclude=excluded_tags, page=1, per_page=1, sticky=True
+            tags=tag_ids,
+            exclude=excluded_tags,
+            page=1,
+            per_page=1,
+            sticky=True,
         )
         # check if the number of returned articles is 0
         if len(latest_pinned_articles[0]) == 0:
             latest_articles = api.get_articles(
-                tags=tag_ids, exclude=excluded_tags, page=1, per_page=4, sticky=False
+                tags=tag_ids,
+                exclude=excluded_tags,
+                page=1,
+                per_page=4,
+                sticky=False,
             )
         else:
             latest_articles = api.get_articles(
-                tags=tag_ids, exclude=excluded_tags, page=1, per_page=3, sticky=False
+                tags=tag_ids,
+                exclude=excluded_tags,
+                page=1,
+                per_page=3,
+                sticky=False,
             )
 
     except Exception:

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -36,8 +36,7 @@ def index(request):
                 tags_exclude=excluded_tags,
                 page=page_param,
                 sticky="true",
-                per_page=3,
-                categories=[category_id]
+                per_page=3
             )
             featured_article_ids = [
                 article["id"] for article in featured_articles

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -51,8 +51,8 @@ def index(request):
             )
         else:
             articles, total_pages = api.get_articles(
-                tags=tag_ids, 
-                page=page_param, 
+                tags=tag_ids,
+                page=page_param,
                 tags_exclude=excluded_tags,
                 categories=[category_id]
             )

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -29,7 +29,6 @@ def index(request):
         if category_param != "":
             category = api.get_category_by_slug(category_param)
             category_id = category["id"]
-            
         if page_param == "1":
             featured_articles, total_pages = api.get_articles(
                 tags=tag_ids,

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -36,24 +36,22 @@ def index(request):
                 tags_exclude=excluded_tags,
                 page=page_param,
                 sticky="true",
-                per_page=3
+                per_page=3,
             )
-            featured_article_ids = [
-                article["id"] for article in featured_articles
-            ]
+            featured_article_ids = [article["id"] for article in featured_articles]
             articles, total_pages = api.get_articles(
                 tags=tag_ids,
                 tags_exclude=excluded_tags,
                 exclude=featured_article_ids,
                 page=page_param,
-                categories=[category_id]
+                categories=[category_id],
             )
         else:
             articles, total_pages = api.get_articles(
                 tags=tag_ids,
                 page=page_param,
                 tags_exclude=excluded_tags,
-                categories=[category_id]
+                categories=[category_id],
             )
             featured_articles = []
 
@@ -107,9 +105,7 @@ def topic(request, slug, template_path):
         tag = api.get_tag_by_slug(slug)
 
         articles, total_pages = api.get_articles(
-            tags=tag_ids + [tag["id"]],
-            tags_exclude=excluded_tags,
-            page=page_param,
+            tags=tag_ids + [tag["id"]], tags_exclude=excluded_tags, page=page_param
         )
 
     except Exception as e:
@@ -147,17 +143,10 @@ def author(request, username):
     try:
         author = api.get_user_by_username(username)
         articles, total_pages = api.get_articles(
-            tags=tag_ids,
-            tags_exclude=excluded_tags,
-            per_page=5,
-            author=author["id"],
+            tags=tag_ids, tags_exclude=excluded_tags, per_page=5, author=author["id"]
         )
 
-        context = {
-            "title": blog_title,
-            "author": author,
-            "latest_articles": articles,
-        }
+        context = {"title": blog_title, "author": author, "latest_articles": articles}
 
         return render(request, "blog/author.html", context)
     except Exception as e:
@@ -209,9 +198,7 @@ def archives(request, template_path="blog/archives.html"):
         total_posts = metadata["total_posts"]
 
         if group:
-            context = get_group_page_context(
-                page, articles, total_pages, group
-            )
+            context = get_group_page_context(page, articles, total_pages, group)
         else:
             context = get_index_context(page, articles, total_pages)
 
@@ -260,28 +247,16 @@ def latest_news(request):
 
     try:
         latest_pinned_articles = api.get_articles(
-            tags=tag_ids,
-            exclude=excluded_tags,
-            page=1,
-            per_page=1,
-            sticky=True,
+            tags=tag_ids, exclude=excluded_tags, page=1, per_page=1, sticky=True
         )
         # check if the number of returned articles is 0
         if len(latest_pinned_articles[0]) == 0:
             latest_articles = api.get_articles(
-                tags=tag_ids,
-                exclude=excluded_tags,
-                page=1,
-                per_page=4,
-                sticky=False,
+                tags=tag_ids, exclude=excluded_tags, page=1, per_page=4, sticky=False
             )
         else:
             latest_articles = api.get_articles(
-                tags=tag_ids,
-                exclude=excluded_tags,
-                page=1,
-                per_page=3,
-                sticky=False,
+                tags=tag_ids, exclude=excluded_tags, page=1, per_page=3, sticky=False
             )
 
     except Exception:


### PR DESCRIPTION
# Done
- Adds the ability to filter by category on /blog

## QA
- Use https://github.com/canonical-web-and-design/www.ubuntu.com and replace `canonicalwebteam.blog==1.5.X` with `git+https://github.com/sowasred2012/canonicalwebteam.blog@add-category-filter-to-index#egg=canonicalwebteam.blog` in `requirements.txt`
- `./run` the site
- Visit `/blog?category=white-papers` and ensure the posts displayed belong to that category