### PR TITLE
Allow filtering by multiple categories on archive view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.5.13: Adds filtering by multiple categories on archive view
 1.5.12: Add next 3 upcoming webinars and events to index
 1.5.11 Adds filtering by category to blog index
 1.5.10: Fix author search and pass more data to author template

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -179,10 +179,10 @@ def author(request, username):
 def archives(request, template_path="blog/archives.html"):
     try:
         page = request.GET.get("page", default="1")
-        category = request.GET.get("category", default="")
         group = request.GET.get("group", default="")
         month = request.GET.get("month", default="")
         year = request.GET.get("year", default="")
+        category_param = request.GET.get("category", default="")
 
         groups = []
         categories = []
@@ -191,9 +191,11 @@ def archives(request, template_path="blog/archives.html"):
             group = api.get_group_by_slug(group)
             groups.append(group["id"])
 
-        if category:
-            category = api.get_category_by_slug(category)
-            categories.append(category["id"])
+        if category_param:
+            category_slugs = category_param.split(",")
+            for slug in category_slugs:
+                category = api.get_category_by_slug(slug)
+                categories.append(category["id"])
 
         after = ""
         before = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "1.5.12"
+version = "1.5.13"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 


### PR DESCRIPTION
# Done
- Add the ability to filter by multiple categories on the blog archive

## QA
- Use https://github.com/canonical-web-and-design/www.ubuntu.com and replace `canonicalwebteam.blog==1.5.X` with `git+https://github.com/sowasred2012/canonicalwebteam.blog@add-category-filter-to-index#egg=canonicalwebteam.blog` in `requirements.txt`
- `./run` the site
- Visit `/blog/archives?category=?category=webinars,events`, ensure the posts displayed belong to those categories and match what is shown on https://blog.ubuntu.com/archives?category=events,webinars