### PR TITLE
get complete upcoming articles, including start and end dates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.5.14: Updates upcoming articles to include additional data
 1.5.13: Adds filtering by multiple categories on archive view
 1.5.12: Add next 3 upcoming webinars and events to index
 1.5.11 Adds filtering by category to blog index

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -44,22 +44,30 @@ def get_complete_article(article, group=None):
     )
 
 
-def get_index_context(page_param, articles, total_pages, featured_articles=[]):
+def get_index_context(
+    page_param, articles, total_pages, featured_articles=[], upcoming=[]
+):
     """
     Build the content for the index page
     :param page_param: String or int for index of the page to get
     :param articles: Array of articles
     :param articles: String of int of total amount of pages
     :param featured_articles: List of featured articles
+    :param upcoming_articles: List of upcoming articles
     """
 
     transformed_articles = []
     transformed_featured_articles = []
+    transformed_upcoming_articles = []
+
     for article in articles:
         transformed_articles.append(get_complete_article(article))
 
     for article in featured_articles:
         transformed_featured_articles.append(get_complete_article(article))
+
+    for article in upcoming:
+        transformed_upcoming_articles.append(get_complete_article(article))
 
     return {
         "current_page": int(page_param),
@@ -68,6 +76,7 @@ def get_index_context(page_param, articles, total_pages, featured_articles=[]):
         "used_categories": category_cache,
         "groups": group_cache,
         "featured_articles": transformed_featured_articles,
+        "upcoming": transformed_upcoming_articles,
     }
 
 

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -72,7 +72,11 @@ def index(request, enable_upcoming=True):
         return HttpResponse("Error: " + e, status=502)
 
     context = get_index_context(
-        page_param, articles, total_pages, featured_articles=featured_articles
+        page_param,
+        articles,
+        total_pages,
+        featured_articles=featured_articles,
+        upcoming=upcoming,
     )
     context["title"] = blog_title
     context["category"] = {"slug": category_param}

--- a/canonicalwebteam/blog/logic.py
+++ b/canonicalwebteam/blog/logic.py
@@ -2,6 +2,7 @@ import re
 import html
 
 from datetime import datetime
+from datetime import date
 
 
 def strip_excerpt(raw_html):
@@ -96,6 +97,18 @@ def transform_article(
             article["content"]["rendered"]
         )
 
+    if "_start_month" in article:
+        start_month_name = get_month_name(int(article["_start_month"]))
+        article["start_date"] = "{} {} {}".format(
+            article["_start_day"], start_month_name, article["_start_year"]
+        )
+
+    if "_end_month" in article:
+        end_month_name = get_month_name(int(article["_end_month"]))
+        article["end_date"] = "{} {} {}".format(
+            article["_end_day"], end_month_name, article["_end_year"]
+        )
+
     return article
 
 
@@ -140,3 +153,12 @@ def is_in_series(tags):
             return True
 
     return False
+
+
+def get_month_name(month_index):
+    """
+    Get the month name from it's number, e.g.:
+    January
+    """
+
+    return date(1900, month_index, 1).strftime("%B")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "1.5.13"
+version = "1.5.14"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 

--- a/tests/test_common_view_logic.py
+++ b/tests/test_common_view_logic.py
@@ -61,6 +61,7 @@ class TestCommonViewLogic(unittest.TestCase):
                 },
             ],
             "groups": {1: "test_group"},
+            "upcoming": [],
             "used_categories": {
                 1: "test_category",
                 2: "test_category",
@@ -158,6 +159,7 @@ class TestCommonViewLogic(unittest.TestCase):
                 },
             ],
             "groups": {1: "test_group"},
+            "upcoming": [],
             "used_categories": {
                 1: "test_category",
                 2: "test_category",
@@ -220,6 +222,7 @@ class TestCommonViewLogic(unittest.TestCase):
                 },
             ],
             "groups": {1: "test_group"},
+            "upcoming": [],
             "used_categories": {
                 1: "test_category",
                 2: "test_category",

--- a/tests/test_django_views.py
+++ b/tests/test_django_views.py
@@ -55,7 +55,11 @@ class TestDjangoViews(unittest.TestCase):
 
         self.assertEqual(self.get_articles_patch.call_count, 3)
         self.get_index_context_patch.assert_called_once_with(
-            "1", [mock_article], "1", featured_articles=[mock_article]
+            "1",
+            [mock_article],
+            "1",
+            featured_articles=[mock_article],
+            upcoming=[mock_article],
         )
 
     # TODO: This test has a problem with the patching method


### PR DESCRIPTION
# Done
- Updated upcoming articles to include image urls, start and end dates, group name etc

## QA
- Use https://github.com/canonical-web-and-design/www.ubuntu.com and replace `canonicalwebteam.blog==1.5.X` with `git+https://github.com/sowasred2012/canonicalwebteam.blog@add-category-filter-to-index#egg=canonicalwebteam.blog` in `requirements.txt`
- `./run` the site
- In the `/blog/index.html` template, add
```
{% for article in upcoming %}
  {{ article.group.name }}
  {{ article.start_date }}
  {{ article.image.source_url }}
{% endfor %}
```
- Ensure you can three sets of the above values for each article