### PR TITLE
include tag slug in tag object

### DIFF
--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -151,7 +151,9 @@ def get_article_context(article, related_tag_ids=[]):
 
     if tag_names_response:
         for tag in tag_names_response:
-            tag_names.append({"id": tag["id"], "name": tag["name"]})
+            tag_names.append(
+                {"id": tag["id"], "name": tag["name"], "slug": tag["slug"]}
+            )
 
     is_in_series = logic.is_in_series(tag_names)
 

--- a/tests/test_common_view_logic.py
+++ b/tests/test_common_view_logic.py
@@ -262,8 +262,8 @@ class TestCommonViewLogic(unittest.TestCase):
         )
         get_user.return_value = "test_author"
         get_tags_by_id.return_value = [
-            {"id": 1, "name": "test_tag_1"},
-            {"id": 2, "name": "test_tag_2"},
+            {"id": 1, "name": "test_tag_1", "slug": "test_tag_1"},
+            {"id": 2, "name": "test_tag_2", "slug": "test_tag_2"},
         ]
         article = {
             "id": 1,
@@ -298,8 +298,8 @@ class TestCommonViewLogic(unittest.TestCase):
                 }
             ],
             "tags": [
-                {"id": 1, "name": "test_tag_1"},
-                {"id": 2, "name": "test_tag_2"},
+                {"id": 1, "name": "test_tag_1", "slug": "test_tag_1"},
+                {"id": 2, "name": "test_tag_2", "slug": "test_tag_2"},
             ],
         }
 
@@ -344,8 +344,8 @@ class TestCommonViewLogic(unittest.TestCase):
         )
         get_user.return_value = "test_author"
         get_tags_by_id.return_value = [
-            {"id": 1, "name": "test_tag_1"},
-            {"id": 2, "name": "test_tag_2"},
+            {"id": 1, "name": "test_tag_1", "slug": "test_tag_1"},
+            {"id": 2, "name": "test_tag_2", "slug": "test_tag_2"},
         ]
         article = {
             "id": 1,
@@ -380,8 +380,8 @@ class TestCommonViewLogic(unittest.TestCase):
                 }
             ],
             "tags": [
-                {"id": 1, "name": "test_tag_1"},
-                {"id": 2, "name": "test_tag_2"},
+                {"id": 1, "name": "test_tag_1", "slug": "test_tag_1"},
+                {"id": 2, "name": "test_tag_2", "slug": "test_tag_2"},
             ],
         }
 


### PR DESCRIPTION
Updates tag objects to include slugs, so that blog articles can include links to tag pages.