### PR TITLE
Extract views to common view

### DIFF
--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -138,6 +138,33 @@ class BlogViews:
             "latest_articles": articles,
         }
 
+    def get_latest_news(self):
+        latest_pinned_articles = api.get_articles(
+            tags=self.tag_ids,
+            exclude=self.excluded_tags,
+            page=1,
+            per_page=1,
+            sticky=True,
+        )
+
+        per_page = 3
+        if latest_pinned_articles:
+            per_page = 4
+
+        latest_articles = api.get_articles(
+            tags=self.tag_ids,
+            exclude=self.excluded_tags,
+            page=1,
+            per_page=per_page,
+            sticky=False,
+        )
+
+        return {
+            "latest_articles": latest_articles,
+            "latest_pinned_articles": latest_pinned_articles,
+        }
+
+
 def get_complete_article(article, group=None):
     """
     This returns any given article from the wordpress API

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -1,5 +1,8 @@
-from canonicalwebteam.blog import wordpress_api as api
+from datetime import datetime
+
 from canonicalwebteam.blog import logic
+from canonicalwebteam.blog import wordpress_api as api
+from dateutil.relativedelta import relativedelta
 
 category_cache = {}
 group_cache = {}
@@ -94,7 +97,7 @@ class BlogViews:
         return context
 
     def get_topic(self, topic_slug, page=1):
-        tag = api.get_tag_by_slug(slug)
+        tag = api.get_tag_by_slug(topic_slug)
 
         articles, total_pages = api.get_articles(
             tags=self.tag_ids + [tag["id"]],
@@ -164,7 +167,7 @@ class BlogViews:
             "latest_pinned_articles": latest_pinned_articles,
         }
 
-    def get_archives(page=1, group="", month="", year="", category=""):
+    def get_archives(self, page=1, group="", month="", year="", category=""):
         groups = []
         categories = []
 
@@ -214,10 +217,10 @@ class BlogViews:
 
         return context
 
-    def get_feed(uri):
+    def get_feed(self, uri):
         feed = api.get_feed(self.tag_name)
         right_urls = logic.change_url(feed, uri.replace("/feed", ""))
-        context = right_urls.replace("Ubuntu Blog", blog_title)
+        context = right_urls.replace("Ubuntu Blog", self.blog_title)
 
         return context
 

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -93,6 +93,20 @@ class BlogViews:
 
         return context
 
+    def get_topic(self, topic_slug, page=1):
+        tag = api.get_tag_by_slug(slug)
+
+        articles, total_pages = api.get_articles(
+            tags=self.tag_ids + [tag["id"]],
+            tags_exclude=self.excluded_tags,
+            page=page,
+        )
+
+        context = get_topic_page_context(page, articles, total_pages)
+        context["title"] = self.blog_title
+
+        return context
+
 
 def get_complete_article(article, group=None):
     """

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -123,6 +123,20 @@ class BlogViews:
 
         return context
 
+    def get_author(self, username):
+        author = api.get_user_by_username(username)
+        articles, total_pages = api.get_articles(
+            tags=self.tag_ids,
+            tags_exclude=self.excluded_tags,
+            per_page=5,
+            author=author["id"],
+        )
+
+        return {
+            "title": self.blog_title,
+            "author": author,
+            "latest_articles": articles,
+        }
 
 def get_complete_article(article, group=None):
     """

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -107,6 +107,22 @@ class BlogViews:
 
         return context
 
+    def get_upcoming(self, page=1):
+        events = api.get_category_by_slug("events")
+        webinars = api.get_category_by_slug("webinars")
+
+        articles, total_pages = api.get_articles(
+            tags=self.tag_ids,
+            tags_exclude=self.excluded_tags,
+            page=page,
+            categories=[events["id"], webinars["id"]],
+        )
+
+        context = get_index_context(page, articles, total_pages)
+        context["title"] = self.blog_title
+
+        return context
+
 
 def get_complete_article(article, group=None):
     """

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -39,32 +39,13 @@ def index(request, enable_upcoming=True):
 
 
 def group(request, slug, template_path):
+    page_param = request.GET.get("page", default="1")
+    category_param = request.GET.get("category", default="")
+
     try:
-        page_param = request.GET.get("page", default="1")
-        category_param = request.GET.get("category", default="")
-
-        group = api.get_group_by_slug(slug)
-        group_id = group["id"]
-
-        category_id = ""
-        if category_param != "":
-            category = api.get_category_by_slug(category_param)
-            category_id = category["id"]
-
-        articles, total_pages = api.get_articles(
-            tags=tag_ids,
-            tags_exclude=excluded_tags,
-            page=page_param,
-            groups=[group_id],
-            categories=[category_id],
-        )
-
+        context = blog_views.get_group(slug, page_param, category_param)
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)
-
-    context = get_group_page_context(page_param, articles, total_pages, group)
-    context["title"] = blog_title
-    context["category"] = {"slug": category_param}
 
     return render(request, template_path, context)
 

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -174,38 +174,9 @@ def article(request, slug):
 
 
 def latest_news(request):
-
     try:
-        latest_pinned_articles = api.get_articles(
-            tags=tag_ids,
-            exclude=excluded_tags,
-            page=1,
-            per_page=1,
-            sticky=True,
-        )
-        # check if the number of returned articles is 0
-        if len(latest_pinned_articles[0]) == 0:
-            latest_articles = api.get_articles(
-                tags=tag_ids,
-                exclude=excluded_tags,
-                page=1,
-                per_page=4,
-                sticky=False,
-            )
-        else:
-            latest_articles = api.get_articles(
-                tags=tag_ids,
-                exclude=excluded_tags,
-                page=1,
-                per_page=3,
-                sticky=False,
-            )
-
+        context = blog.get_latest_news()
     except Exception:
         return JsonResponse({"Error": "An error ocurred"}, status=502)
-    return JsonResponse(
-        {
-            "latest_articles": latest_articles,
-            "latest_pinned_articles": latest_pinned_articles,
-        }
-    )
+
+    return JsonResponse(context)

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -74,20 +74,7 @@ def upcoming(request):
 
 def author(request, username):
     try:
-        author = api.get_user_by_username(username)
-        articles, total_pages = api.get_articles(
-            tags=tag_ids,
-            tags_exclude=excluded_tags,
-            per_page=5,
-            author=author["id"],
-        )
-
-        context = {
-            "title": blog_title,
-            "author": author,
-            "latest_articles": articles,
-        }
-
+        context = blog_views.get_author(username)
         return render(request, "blog/author.html", context)
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -1,18 +1,7 @@
-from datetime import datetime
-
-
-from canonicalwebteam.blog import wordpress_api as api
-from canonicalwebteam.blog import logic
-from canonicalwebteam.blog.common_view_logic import (
-    BlogViews,
-    get_index_context,
-    get_group_page_context,
-    get_topic_page_context,
-)
-from dateutil.relativedelta import relativedelta
+from canonicalwebteam.blog.common_view_logic import BlogViews
 from django.conf import settings
-from django.http import HttpResponseNotFound, HttpResponse, JsonResponse
-from django.shortcuts import render, redirect
+from django.http import HttpResponse, HttpResponseNotFound, JsonResponse
+from django.shortcuts import redirect, render
 
 tag_ids = settings.BLOG_CONFIG["TAG_IDS"]
 excluded_tags = settings.BLOG_CONFIG["EXCLUDED_TAGS"]
@@ -88,7 +77,9 @@ def archives(request, template_path="blog/archives.html"):
     category_param = request.GET.get("category", default="")
 
     try:
-        context = blog_views.get_archives(page, group, month, year, category_param)
+        context = blog_views.get_archives(
+            page, group, month, year, category_param
+        )
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)
 
@@ -97,11 +88,11 @@ def archives(request, template_path="blog/archives.html"):
 
 def feed(request):
     try:
-        blog_views.get_feed(request.build_absolute_uri())
+        context = blog_views.get_feed(request.build_absolute_uri())
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)
 
-    return HttpResponse(right_title, status=200, content_type="txt/xml")
+    return HttpResponse(context, status=200, content_type="txt/xml")
 
 
 def article_redirect(request, slug, year=None, month=None, day=None):
@@ -122,7 +113,7 @@ def article(request, slug):
 
 def latest_news(request):
     try:
-        context = blog.get_latest_news()
+        context = blog_views.get_latest_news()
     except Exception:
         return JsonResponse({"Error": "An error ocurred"}, status=502)
 

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -51,21 +51,12 @@ def group(request, slug, template_path):
 
 
 def topic(request, slug, template_path):
+    page_param = request.GET.get("page", default="1")
+
     try:
-        page_param = request.GET.get("page", default="1")
-
-        tag = api.get_tag_by_slug(slug)
-
-        articles, total_pages = api.get_articles(
-            tags=tag_ids + [tag["id"]],
-            tags_exclude=excluded_tags,
-            page=page_param,
-        )
-
+        context = blog_views.get_topic(slug, page_param)
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)
-    context = get_topic_page_context(page_param, articles, total_pages)
-    context["title"] = blog_title
 
     return render(request, template_path, context)
 

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -81,78 +81,25 @@ def author(request, username):
 
 
 def archives(request, template_path="blog/archives.html"):
+    page = request.GET.get("page", default="1")
+    group = request.GET.get("group", default="")
+    month = request.GET.get("month", default="")
+    year = request.GET.get("year", default="")
+    category_param = request.GET.get("category", default="")
+
     try:
-        page = request.GET.get("page", default="1")
-        group = request.GET.get("group", default="")
-        month = request.GET.get("month", default="")
-        year = request.GET.get("year", default="")
-        category_param = request.GET.get("category", default="")
-
-        groups = []
-        categories = []
-
-        if group:
-            group = api.get_group_by_slug(group)
-            groups.append(group["id"])
-
-        if category_param:
-            category_slugs = category_param.split(",")
-            for slug in category_slugs:
-                category = api.get_category_by_slug(slug)
-                categories.append(category["id"])
-
-        after = ""
-        before = ""
-        if year:
-            year = int(year)
-            if month:
-                month = int(month)
-                after = datetime(year=year, month=month, day=1)
-                before = after + relativedelta(months=1)
-            else:
-                after = datetime(year=year, month=1, day=1)
-                before = datetime(year=year, month=12, day=31)
-
-        articles, metadata = api.get_articles_with_metadata(
-            tags=tag_ids,
-            tags_exclude=excluded_tags,
-            page=page,
-            groups=groups,
-            categories=categories,
-            after=after,
-            before=before,
-        )
-
-        total_pages = metadata["total_pages"]
-        total_posts = metadata["total_posts"]
-
-        if group:
-            context = get_group_page_context(
-                page, articles, total_pages, group
-            )
-        else:
-            context = get_index_context(page, articles, total_pages)
-
-        context["title"] = blog_title
-        context["total_posts"] = total_posts
-
-        return render(request, template_path, context)
-
+        context = blog_views.get_archives(page, group, month, year, category_param)
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)
+
+    return render(request, template_path, context)
 
 
 def feed(request):
     try:
-        feed = api.get_feed(tag_name)
+        blog_views.get_feed(request.build_absolute_uri())
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)
-
-    right_urls = logic.change_url(
-        feed, request.build_absolute_uri().replace("/feed", "")
-    )
-
-    right_title = right_urls.replace("Ubuntu Blog", blog_title)
 
     return HttpResponse(right_title, status=200, content_type="txt/xml")
 

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -62,24 +62,12 @@ def topic(request, slug, template_path):
 
 
 def upcoming(request):
+    page_param = request.GET.get("page", default="1")
+
     try:
-        page_param = request.GET.get("page", default="1")
-
-        events = api.get_category_by_slug("events")
-        webinars = api.get_category_by_slug("webinars")
-
-        articles, total_pages = api.get_articles(
-            tags=tag_ids,
-            tags_exclude=excluded_tags,
-            page=page_param,
-            categories=[events["id"], webinars["id"]],
-        )
-
+        context = blog_views.get_upcoming(page_param)
     except Exception as e:
         return HttpResponse("Error: " + e, status=502)
-
-    context = get_index_context(page_param, articles, total_pages)
-    context["title"] = blog_title
 
     return render(request, "blog/upcoming.html", context)
 

--- a/canonicalwebteam/blog/logic.py
+++ b/canonicalwebteam/blog/logic.py
@@ -170,3 +170,66 @@ def get_month_name(month_index):
     """
 
     return date(1900, month_index, 1).strftime("%B")
+
+
+def get_embedded_categories(embedded):
+    """Returns the categories in the embedded response from wp
+    The category is in the first object of the wp:term of the response:
+    embedded["wp:term"][0]
+
+
+    :param embedded: The embedded dictionnary in teh response
+    :returns: Dictionnary of categories
+    """
+    terms = embedded.get("wp:term", [{}])
+    return terms[0]
+
+
+def get_embedded_group(embedded):
+    """Returns the group in the embedded response from wp.
+    The group is in the fourth object of the wp:term list of the response:
+    embedded["wp:term"][3]
+
+
+    :param embedded: The embedded dictionnary in the response
+    :returns: Dictionnary of group
+    """
+    if "wp:term" in embedded and embedded["wp:term"][3]:
+        return embedded["wp:term"][3][0]
+    return {}
+
+
+def get_embedded_author(embedded):
+    """Returns the author in the embedded response from wp.
+    embedded["author"]
+
+
+    :param embedded: The embedded dictionnary in the response
+    :returns: Dictionnary of author
+    """
+    authors = embedded.get("author", [{}])
+    return authors[0]
+
+
+def get_embedded_featured_media(embedded):
+    """Returns the featured media in the embedded response from wp.
+    embedded["wp:featuredmedia"]
+
+
+    :param embedded: The embedded dictionnary in the response
+    :returns: List of featuredmedia
+    """
+    return embedded.get("wp:featuredmedia", [])
+
+
+def get_embedded_tags(embedded):
+    """Returns the tags in the embedded response from wp.
+    The group is in the fourth object of the wp:term list of the response:
+    embedded["wp:term"][1]
+
+
+    :param embedded: The embedded dictionnary in the response
+    :returns: Dictionnary of tags
+    """
+    terms = embedded.get("wp:term", [{}, {}])
+    return terms[1]


### PR DESCRIPTION
# Summary

Wait for https://github.com/canonical-web-and-design/canonicalwebteam.blog/pull/74 to be merged before
Extracted all remaining views from django view file to common view file. No major changes done. List of endpoint:

- author, archives, latest news, feed, upcoming, topic, group 


# QA

 ## I know I am not using the run script this is to make it easier to dev and qa

On this branch:
- `poetry`
- `poetry build`
- copy setup.py to the root of the project


On ubuntu.com

- comment blog module and add this branch

```git
diff --git a/requirements.txt b/requirements.txt
index 1de469c..e4e20ad 100644
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.2
-canonicalwebteam.blog==1.3.5
+# canonicalwebteam.blog==1.3.5
 canonicalwebteam.http==1.0.1
 canonicalwebteam.versioned-static==1.0.2
 canonicalwebteam.yaml-responses[django]==1.1.0
@@ -9,3 +9,5 @@ django-template-finder-view==0.3
 whitenoise==4.1.2
 talisker==0.14.2
 gunicorn[gevent]
+
+-e file:///home/tbmb/Documents/projects/blog-flask-extension#egg=canonicalwebteam.blog
```

- On a python 3 virtualenv
- `pip install -r requirements.txt`
- `yarn && yarn build`
- `python manage.py runserver`

Go on the article pages and make sure it works
