### PR TITLE
Shorten default cache to 5 minutes

### DIFF
--- a/canonicalwebteam/blog/wordpress_api.py
+++ b/canonicalwebteam/blog/wordpress_api.py
@@ -8,7 +8,7 @@ API_URL = os.getenv(
 )
 
 
-api_session = CachedSession(fallback_cache_duration=3600)
+api_session = CachedSession(fallback_cache_duration=300)
 
 tags = {}
 


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/blog.ubuntu.com/issues/386#event-2358565226

QA
--

`./run`, load the homepage - see how long it takes. Refresh it, check it's quicker.