### PR TITLE
Get complete article in article view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+2.0.2: Update article context to return complete article
 2.0.0: Wordpress api optimisation, flask support and added tag endpoint.
 1.5.15: Bugfix on date parsing in logic.py
 1.5.14: Updates upcoming articles to include additional data

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -332,11 +332,7 @@ def get_article_context(article, related_tag_ids=[], excluded_tags=[]):
     Build the content for the article page
     :param article: Article to create context for
     """
-    author = logic.get_embedded_author(article["_embedded"])
-
-    transformed_article = logic.transform_article(
-        article, author=author, optimise_images=True
-    )
+    transformed_article = get_complete_article(article)
 
     tags = logic.get_embedded_tags(article["_embedded"])
     is_in_series = logic.is_in_series(tags)
@@ -352,8 +348,6 @@ def get_article_context(article, related_tag_ids=[], excluded_tags=[]):
     for related_article in all_related_articles:
         if set(related_tag_ids) <= set(related_article["tags"]):
             related_articles.append(logic.transform_article(related_article))
-
-    article["group"] = logic.get_embedded_group(article["_embedded"])
 
     return {
         "article": transformed_article,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "2.0.1"
+version = "2.0.2"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 

--- a/tests/test_common_view_logic.py
+++ b/tests/test_common_view_logic.py
@@ -115,9 +115,7 @@ class TestCommonViewLogic(unittest.TestCase):
         article_context = get_article_context(article)
 
         self.assertIsNotNone(article_context["article"]["author"]["name"])
-        self.assertTrue(
-            "cloudinary" in article_context["article"]["content"]["rendered"]
-        )
+        self.assertIsNotNone(article_context["article"]["image"])
         self.assertIsNotNone(article_context["article"]["topic"])
 
         self.assertEqual(len(article_context["related_articles"]), 3)


### PR DESCRIPTION
## Done
- Article views use featured images for social sharing links, so use existing `get_complete_article` logic to make sure they're available where possible