### PR TITLE
Fix archives 500

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+2.0.10: Fix get_archives error caused by default after/before params being empty strings
 2.0.4: Internal API refactor
 2.0.3: Add pagination for author endpoint
 2.0.2: Update article context to return complete article

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -186,8 +186,8 @@ class BlogViews:
                 category = api.get_category_by_slug(slug)
                 categories.append(category["id"])
 
-        after = ""
-        before = ""
+        after = None
+        before = None
         if year:
             year = int(year)
             if month:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "2.0.9"
+version = "2.0.10"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 


### PR DESCRIPTION
## Done
- Set `after` and `before` default values to `None` in the `get_archives` method.
  - The Wordpress API returns an error if the `after` and `before` values are empty strings, which was the case unless a `year` param was present in the URL.

## QA
- Use https://github.com/canonical-web-and-design/kubeflow-news.com and replace `canonicalwebteam.blog==2.0.x` with `git+https://github.com/sowasred2012/canonicalwebteam.blog@fix-archives-500#egg=canonicalwebteam.blog` in `requirements.txt`
- Run `./run clean && ./run`
- Visit [/archives](http://0.0.0.0:8035/archives)
- Ensure that you see the archives page, rather than an error