### PR TITLE
Fix 404 not raised in tag endpoint

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+2.0.13: Fix 404 not raised on tag endpoint
 2.0.12: Handle 404 with Exception in Django
 2.0.11: Fix error of int conversion for page parameter on Django
 2.0.10: Fix get_archives error caused by default after/before params being empty strings

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -135,6 +135,6 @@ def tag(request, slug):
     try:
         context = blog_views.get_tag(slug, page_param)
     except Exception:
-        return Http404("Tag not found")
+        raise Http404("Tag not found")
 
     return render(request, "blog/tag.html", context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "2.0.12"
+version = "2.0.13"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 


### PR DESCRIPTION
Instead of raising the Http404 I was return it in the tag endpoint.

Ex. https://ubuntu.com/blog/tag/c39e0fed-apple-touch-icon.png
Fixes https://sentry.is.canonical.com/canonical/ubuntu-com/issues/2469/?query=is%3Aunresolved