### PR TITLE
Return 404 on author not found

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+2.0.14: Return 404 when author not found
 2.0.13: Fix 404 not raised on tag endpoint
 2.0.12: Handle 404 with Exception in Django
 2.0.11: Fix error of int conversion for page parameter on Django

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -131,6 +131,9 @@ class BlogViews:
     def get_author(self, username, page=1):
         author = api.get_user_by_username(username)
 
+        if not author:
+            return None
+
         articles, metadata = api.get_articles(
             tags=self.tag_ids,
             tags_exclude=self.excluded_tags,

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -73,9 +73,13 @@ def author(request, username):
 
     try:
         context = blog_views.get_author(username, page_param)
-        return render(request, "blog/author.html", context)
     except Exception as e:
         return HttpResponse("Error: " + str(e), status=502)
+
+    if not context:
+        raise Http404("Author not found")
+
+    return render(request, "blog/author.html", context)
 
 
 def archives(request, template_path="blog/archives.html"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "2.0.13"
+version = "2.0.14"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 


### PR DESCRIPTION
# Summary

Return 404 on author not found.
Fixes https://sentry.is.canonical.com/canonical/ubuntu-com/issues/2173/?query=is%3Aunresolved

# QA

- Add this branch to the ubuntu.com project as a requirement
- `./run`
- http://0.0.0.0:8001/blog/author/aaaaaaaaaaaaaaaaaaaaaaa
- should get a 404 page