### PR TITLE
Redirect latest endnpoint to article page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+2.1.1: Redirect latest endpoint to latest article page
 2.1.0: Add latest article endpoint ("/latest")
 2.0.14: Return 404 when author not found
 2.0.13: Fix 404 not raised on tag endpoint

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -40,7 +40,7 @@ def latest_article(request):
     except Exception as e:
         return HttpResponse("Error: " + str(e), status=502)
 
-    return render(request, "blog/article.html", context)
+    return redirect("article", slug=context.get("article").get("slug"))
 
 
 def group(request, slug, template_path):

--- a/canonicalwebteam/blog/flask/views.py
+++ b/canonicalwebteam/blog/flask/views.py
@@ -37,7 +37,9 @@ def build_blueprint(
         except Exception:
             return flask.abort(502)
 
-        return flask.render_template("blog/article.html", **context)
+        return flask.redirect(
+            flask.url_for(".article", slug=context.get("article").get("slug"))
+        )
 
     @blog.route("/feed")
     def feed():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "2.1.0"
+version = "2.1.1"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 


### PR DESCRIPTION
# Summary 

Redirect latest endoin to article page: `/latest` -> `/<slug>`

# Qa

- Add this branch to `kubeflow-news.com` 
- acces `/latest` should be redirect to latest article posted `/<slug>`