### PR TITLE
Order feeds from most recent to oldest

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+2.4.1: List feeds from most recent to oldest
 2.4.0: Add feeds endpoints for groups, topics and authors
 2.3.0: Use uncached sessions for API calls
 2.2.1: Fix up default Title setting for blog feed

--- a/canonicalwebteam/blog/feeds.py
+++ b/canonicalwebteam/blog/feeds.py
@@ -13,7 +13,7 @@ def build_feed(uri, path, title, subtitle, articles):
     feed.description(f"{title} feeds")
 
     for article in articles:
-        feed.add_entry(build_entry(article, blog_uri))
+        feed.add_entry(build_entry(article, blog_uri), order="append")
 
     return feed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "2.4.0"
+version = "2.4.1"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     name='canonicalwebteam.blog',  # Required
     # https://www.python.org/dev/peps/pep-0440/
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='2.4.0',  # Required
+    version='2.4.1',  # Required
     # https://packaging.python.org/specifications/core-metadata/#summary
     description="Flask extension and Django App to add a nice blog to your website",  # Required
     # https://packaging.python.org/specifications/core-metadata/#description-optional


### PR DESCRIPTION
# Done
Show most recent entries first in feeds endpoints.

# QA
- In `www.ubuntu.com` replace the `canonicalwebteam.blog` dependency with this branch.
- Go to feeds endpoints and make sure the most recent entries come first.