### PR TITLE
Fixes for /latest-news JSON endpoint

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+3.1.1: Fixes for /latest-news JSON endpoint
 3.1.0: Allow setting feed_description through BlogViews
 3.0.1: Fix 404s for groups
 3.0.0: Change Flask interface to expose BlogViews

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -261,19 +261,21 @@ class BlogViews:
     def get_latest_news(self):
         latest_pinned_articles, _ = api.get_articles(
             tags=self.tag_ids,
-            exclude=self.excluded_tags,
+            tags_exclude=self.excluded_tags,
             page=1,
             per_page=1,
             sticky=True,
         )
 
-        per_page = 3
+        per_page = 4
+
         if latest_pinned_articles:
-            per_page = 4
+            per_page = 3
 
         latest_articles, _ = api.get_articles(
             tags=self.tag_ids,
-            exclude=self.excluded_tags,
+            tags_exclude=self.excluded_tags,
+            exclude=[article["id"] for article in latest_pinned_articles],
             page=1,
             per_page=per_page,
             sticky=False,

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -179,9 +179,8 @@ class BlogViews:
         if not tag:
             return None
 
-        tag_ids = self.tag_ids + [tag["id"]]
         articles, _ = api.get_articles(
-            tags=tag_ids, tags_exclude=self.excluded_tags, cache=False
+            tags=[tag["id"]], tags_exclude=self.excluded_tags, cache=False
         )
 
         title = f"{tag['name']} - {self.blog_title}"
@@ -258,26 +257,21 @@ class BlogViews:
 
         return feed.rss_str()
 
-    def get_latest_news(self):
+    def get_latest_news(self, limit=3, tag_ids=[]):
         latest_pinned_articles, _ = api.get_articles(
-            tags=self.tag_ids,
+            tags=tag_ids or self.tag_ids,
             tags_exclude=self.excluded_tags,
             page=1,
             per_page=1,
             sticky=True,
         )
 
-        per_page = 4
-
-        if latest_pinned_articles:
-            per_page = 3
-
         latest_articles, _ = api.get_articles(
             tags=self.tag_ids,
             tags_exclude=self.excluded_tags,
             exclude=[article["id"] for article in latest_pinned_articles],
             page=1,
-            per_page=per_page,
+            per_page=limit,
             sticky=False,
         )
 
@@ -347,9 +341,7 @@ class BlogViews:
             return None
 
         articles, metadata = api.get_articles(
-            tags=self.tag_ids + [tag["id"]],
-            tags_exclude=self.excluded_tags,
-            page=page,
+            tags=[tag["id"]], tags_exclude=self.excluded_tags, page=page
         )
         total_pages = metadata["total_pages"]
 

--- a/canonicalwebteam/blog/flask.py
+++ b/canonicalwebteam/blog/flask.py
@@ -57,7 +57,10 @@ def build_blueprint(blog_views, enable_upcoming=True):
 
     @blueprint.route("/latest-news")
     def latest_news():
-        context = blog_views.get_latest_news()
+        context = blog_views.get_latest_news(
+            tag_ids=flask.request.args.getlist("tag-id"),
+            limit=flask.request.args.get("limit", "3"),
+        )
 
         return flask.jsonify(context)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "3.1.0"
+version = "3.1.1"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     name='canonicalwebteam.blog',  # Required
     # https://www.python.org/dev/peps/pep-0440/
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='3.1.0',  # Required
+    version='3.1.1',  # Required
     # https://packaging.python.org/specifications/core-metadata/#summary
     description="Flask extension and Django App to add a nice blog to your website",  # Required
     # https://packaging.python.org/specifications/core-metadata/#description-optional


### PR DESCRIPTION
- Make sure we're excluding the excluded tags properly
- Return 4 articles if there is no spotlight, or 3 otherwise (rather than
the other way around)
- Exclude the spotlight article from the "Latest news" list

QA
--

QA by testing the demo in https://github.com/canonical-web-and-design/ubuntu.com/pull/5786 - https://ubuntu-com-canonical-web-and-design-pr-5786.run.demo.haus/