### PR TITLE
v3.1.1: Filter /latest-news JSON endpoint by group

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+3.1.2: Filter /latest-news JSON endpoint by group
 3.1.1: Fixes for /latest-news JSON endpoint
 3.1.0: Allow setting feed_description through BlogViews
 3.0.1: Fix 404s for groups

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -257,18 +257,20 @@ class BlogViews:
 
         return feed.rss_str()
 
-    def get_latest_news(self, limit=3, tag_ids=[]):
+    def get_latest_news(self, limit=3, tag_ids=None, group_ids=None):
         latest_pinned_articles, _ = api.get_articles(
             tags=tag_ids or self.tag_ids,
             tags_exclude=self.excluded_tags,
+            groups=group_ids,
             page=1,
             per_page=1,
             sticky=True,
         )
 
         latest_articles, _ = api.get_articles(
-            tags=self.tag_ids,
+            tags=tag_ids or self.tag_ids,
             tags_exclude=self.excluded_tags,
+            groups=group_ids,
             exclude=[article["id"] for article in latest_pinned_articles],
             page=1,
             per_page=limit,

--- a/canonicalwebteam/blog/flask.py
+++ b/canonicalwebteam/blog/flask.py
@@ -59,6 +59,7 @@ def build_blueprint(blog_views, enable_upcoming=True):
     def latest_news():
         context = blog_views.get_latest_news(
             tag_ids=flask.request.args.getlist("tag-id"),
+            group_ids=flask.request.args.getlist("group-id"),
             limit=flask.request.args.get("limit", "3"),
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "3.1.1"
+version = "3.1.2"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     name='canonicalwebteam.blog',  # Required
     # https://www.python.org/dev/peps/pep-0440/
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='3.1.1',  # Required
+    version='3.1.2',  # Required
     # https://packaging.python.org/specifications/core-metadata/#summary
     description="Flask extension and Django App to add a nice blog to your website",  # Required
     # https://packaging.python.org/specifications/core-metadata/#description-optional


### PR DESCRIPTION
QA using https://github.com/canonical-web-and-design/ubuntu.com/pull/5795

Demo: https://ubuntu-com-canonical-web-and-design-pr-5795.run.demo.haus/

Go to:

- `/security`
- `/internet-of-things`
- `/telecommunications`
- `/legal/ubuntu-advantage-service-description`
- `/` (homepage)

Check the blog feed lists look the same as they do on live.