### PR TITLE
Add `per_page` to blog views

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+4.0.1: Add `per_page` to blog views
 4.0.0: Swap to uncached session
 3.1.2: Filter /latest-news JSON endpoint by group
 3.1.1: Fixes for /latest-news JSON endpoint

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This extension provides a blueprint with 3 routes:
 - "/": that returns the list of articles
 - "/<slug>": the article page
 - "/feed": provides a RSS feed for the page.
-	
+
 ## How to install
 
 To install this extension as a requirement in your project, you can use PIP;
@@ -23,7 +23,7 @@ See also the documentation for (pip install)[https://pip.pypa.io/en/stable/refer
 
 ### Templates
 
-The module expects HTML templates at `blog/index.html`, `blog/article.html`, `blog/blog-card.html`, `blog/archives.html`, `blog/upcoming.html` and `blog/author.html`. 
+The module expects HTML templates at `blog/index.html`, `blog/article.html`, `blog/blog-card.html`, `blog/archives.html`, `blog/upcoming.html` and `blog/author.html`.
 
 An example of these templates can be found at https://github.com/canonical-websites/jp.ubuntu.com/tree/master/templates/blog.
 
@@ -52,6 +52,7 @@ You can customise the blog through the following optional arguments:
         tag_ids=[1, 12, 112],
         exclude_tags=[26, 34],
         feed_description="The Ubuntu Blog Feed",
+        per_page=12, # OPTIONAL (defaults to 12)
     )
     app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
 ```
@@ -72,10 +73,14 @@ urlpatterns = [path("blog/", include("canonicalwebteam.blog.django.urls"))]
 BLOG_CONFIG = {
     # the id for tags that should be fetched for this blog
     "TAGS_ID": [3184],
+    # tag ids we don't want to retrieve posts from wordpress
+    "EXCLUDED_TAGS": [3185],
     # the title of the blog
     "BLOG_TITLE": "TITLE OF THE BLOG",
-    # the tag name for generating a feed
-    "TAG_NAME": "TAG NAME FOR GENERATING A FEED",
+    # [OPTIONAL] title seen on the RSS feed
+    "FEED_DESCRIPTION": "The Amazing blog",
+    # [OPTIONAL] number of articles per page (defaults to 12)
+    "PER_PAGE": 12,
 }
 ```
 
@@ -85,7 +90,7 @@ BLOG_CONFIG = {
 
 - Group pages are optional and can be enabled by using the view `canonicalwebteam.blog.django.views.group`. The view takes the group slug to fetch data for and a template path to load the correct template from.
 - Group pages can be filtered by category, by adding a `category=CATEGORY_NAME` query parameter to the URL (e.g. `http://localhost:8080/blog/cloud-and-server?category=articles`).
-  
+
 ```python
 from canonicalwebteam.blog.django.views import group
 

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -14,11 +14,13 @@ class BlogViews:
         excluded_tags=[],
         blog_title="Blog",
         feed_description=None,
+        per_page=12,
     ):
         self.tag_ids = tag_ids
         self.excluded_tags = excluded_tags
         self.blog_title = blog_title
         self.feed_description = feed_description or f"{blog_title} feed"
+        self.per_page = per_page
 
     def get_index(self, page=1, category="", enable_upcoming=True):
         categories = []
@@ -56,6 +58,7 @@ class BlogViews:
             tags_exclude=self.excluded_tags,
             exclude=[article["id"] for article in featured_articles],
             page=page,
+            per_page=self.per_page,
             categories=categories,
         )
         total_pages = metadata["total_pages"]

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -7,8 +7,17 @@ from django.shortcuts import redirect, render
 tag_ids = settings.BLOG_CONFIG["TAG_IDS"]
 excluded_tags = settings.BLOG_CONFIG["EXCLUDED_TAGS"]
 blog_title = settings.BLOG_CONFIG["BLOG_TITLE"]
+feed_description = settings.BLOG_CONFIG.get("FEED_DESCRIPTION")
+per_page = settings.BLOG_CONFIG.get("PER_PAGE", 12)
 
-blog_views = BlogViews(tag_ids, excluded_tags, blog_title)
+
+blog_views = BlogViews(
+    tag_ids=tag_ids,
+    excluded_tags=excluded_tags,
+    blog_title=blog_title,
+    feed_description=feed_description,
+    per_page=per_page,
+)
 
 
 def str_to_int(string):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.blog"
-version = "4.0.0"
+version = "4.0.1"
 description = "Flask extension and Django App to add a nice blog to your website"
 authors = ["Canonical webteam <webteam@canonical.com>"]
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     name='canonicalwebteam.blog',  # Required
     # https://www.python.org/dev/peps/pep-0440/
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='4.0.0',  # Required
+    version='4.0.1',  # Required
     # https://packaging.python.org/specifications/core-metadata/#summary
     description="Flask extension and Django App to add a nice blog to your website",  # Required
     # https://packaging.python.org/specifications/core-metadata/#description-optional


### PR DESCRIPTION
Add the possibility to control the default number of articles per page
by passing a `per_page` parameter when initializing BlogViews.

## QA
https://github.com/canonical-web-and-design/ubuntu.com/pull/6084/files