### PR TITLE
Fetching events within past six months for upcoming events

### DIFF
--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -45,12 +45,14 @@ class BlogViews:
                 # this going to move
                 events = api.get_category_by_slug("events")
                 webinars = api.get_category_by_slug("webinars")
+                date_after = (datetime.now() - relativedelta(months=6)).isoformat()
                 upcoming, _ = api.get_articles(
                     tags=self.tag_ids,
                     tags_exclude=self.excluded_tags,
                     page=page,
                     per_page=3,
                     categories=[events["id"], webinars["id"]],
+                    after=date_after
                 )
 
         articles, metadata = api.get_articles(

--- a/canonicalwebteam/blog/common_view_logic.py
+++ b/canonicalwebteam/blog/common_view_logic.py
@@ -45,14 +45,16 @@ class BlogViews:
                 # this going to move
                 events = api.get_category_by_slug("events")
                 webinars = api.get_category_by_slug("webinars")
-                date_after = (datetime.now() - relativedelta(months=6)).isoformat()
+                date_after = (
+                    datetime.now() - relativedelta(months=6)
+                ).isoformat()
                 upcoming, _ = api.get_articles(
                     tags=self.tag_ids,
                     tags_exclude=self.excluded_tags,
                     page=page,
                     per_page=3,
                     categories=[events["id"], webinars["id"]],
-                    after=date_after
+                    after=date_after,
                 )
 
         articles, metadata = api.get_articles(


### PR DESCRIPTION

Fixes issue [6114](https://github.com/canonical-web-and-design/ubuntu.com/issues/6114)

Fetching events within past six months for upcoming events section in blog homepage.