### PR TITLE
WordPress imported but never used in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In your app you can then do the following:
 import flask
 import talisker.requests
 from flask_reggie import Reggie
-from canonicalwebteam.blog import BlogViews, build_blueprint
+from canonicalwebteam.blog import BlogViews, build_blueprint, BlogAPI
 
 app = flask.Flask(__name__)
 Reggie().init_app(app)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In your app you can then do the following:
 import flask
 import talisker.requests
 from flask_reggie import Reggie
-from canonicalwebteam.blog import BlogViews, build_blueprint, Wordpress
+from canonicalwebteam.blog import BlogViews, build_blueprint
 
 app = flask.Flask(__name__)
 Reggie().init_app(app)


### PR DESCRIPTION
# Summary

Removed `WordPress` import which is never used. This causes lint error