### PR TITLE
Fix 503 error for API consumers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+6.2.0: Fix 503 instead of 404 status for articles not found
 6.1.1: Restructure; Use `image_template` for images processing
 6.1.0: Restructure; Add API wrapper; Remove helpers
 6.0.0: Restructure; Force passing in session; Remove poetry

--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -133,13 +133,17 @@ class BlogAPI(Wordpress):
             article["end_date"] = "{} {} {}".format(
                 article["_end_day"], end_month_name, article["_end_year"]
             )
+        if "content" in article:
+            # replace url on the blog article page
+            article["content"]["rendered"] = self._replace_url(
+                article["content"]["rendered"]
+            )
 
-        # replace url on the blog article page
-        article["content"]["rendered"] = self._replace_url(
-            article["content"]["rendered"]
-        )
-
-        if article["image"] is not None and "source_url" in article["image"]:
+        if (
+            "image" in article
+            and article["image"] is not None
+            and "source_url" in article["image"]
+        ):
             # replace url from the image thumbnail
             article["image"]["source_url"] = self._replace_url(
                 article["image"]["source_url"]
@@ -153,21 +157,23 @@ class BlogAPI(Wordpress):
             )
 
         if self.use_image_template:
-            # apply image template for blog article images
-            article["content"]["rendered"] = self._apply_image_template(
-                content=article["content"]["rendered"], width="720",
-            )
-
-            # apply image template to thumbnail image
-            if (
-                article["image"] is not None
-                and "source_url" in article["image"]
-            ):
-                article["image"]["rendered"] = self._apply_image_template(
-                    content=article["image"]["rendered"],
-                    width="330",
-                    height="177",
+            if "content" in article:
+                # apply image template for blog article images
+                article["content"]["rendered"] = self._apply_image_template(
+                    content=article["content"]["rendered"], width="720",
                 )
+
+            if "image" in article:
+                # apply image template to thumbnail image
+                if (
+                    article["image"] is not None
+                    and "source_url" in article["image"]
+                ):
+                    article["image"]["rendered"] = self._apply_image_template(
+                        content=article["image"]["rendered"],
+                        width="330",
+                        height="177",
+                    )
 
         return article
 

--- a/canonicalwebteam/blog/wordpress.py
+++ b/canonicalwebteam/blog/wordpress.py
@@ -111,9 +111,12 @@ class Wordpress:
         Get an article from Wordpress api
         :param slug: Article slug to fetch
         """
-        return self.get_first_item(
-            "posts", {"slug": slug, "tags": tags, "tags_exclude": tags_exclude}
-        )
+        try:
+            return self.get_first_item(
+                "posts", {"slug": slug, "tags": tags, "tags_exclude": tags_exclude}
+            )
+        except NotFoundError:
+            return {}
 
     def get_tag_by_id(self, id):
         return self.request(f"tags/{id}").json()

--- a/canonicalwebteam/blog/wordpress.py
+++ b/canonicalwebteam/blog/wordpress.py
@@ -113,7 +113,8 @@ class Wordpress:
         """
         try:
             return self.get_first_item(
-                "posts", {"slug": slug, "tags": tags, "tags_exclude": tags_exclude}
+                "posts",
+                {"slug": slug, "tags": tags, "tags_exclude": tags_exclude},
             )
         except NotFoundError:
             return {}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.1.1",
+    version="6.2.0",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_blog_api.py
+++ b/tests/test_blog_api.py
@@ -17,8 +17,8 @@ class TestBlogAPI(VCRTestCase):
             self.assertTrue(int(metadata["total_pages"]) >= 258)
             self.assertTrue(int(metadata["total_posts"]) >= 3095)
 
-        with self.assertRaises(NotFoundError):
-            self.api.get_article(slug="nonexistent-slug")
+        no_article = self.api.get_article(slug="nonexistent-slug")
+        self.assertEqual(no_article, {})
 
     def test_get_articles_with_transforming_links(self):
         self.api = BlogAPI(

--- a/tests/test_wordpress.py
+++ b/tests/test_wordpress.py
@@ -20,11 +20,10 @@ class TestWordpress(VCRTestCase):
         for article in articles:
             self.assertTrue("rendered" in article["content"])
 
-        with self.assertRaises(NotFoundError):
-            self.api.get_article(slug="nonexistent-slug")
-
+        no_article = self.api.get_article(slug="nonexistent-slug")
+        self.assertEqual(no_article, {})
+            
         article = self.api.get_article(slug="testing-your-user-contract")
-
         self.assertEqual(
             article["title"]["rendered"], "Testing your user contract"
         )


### PR DESCRIPTION
## Summary
- Previously raised error returns a 503 to the API consumer
- This will ensure a 403 is returned and the consumer can handle this error
- This was also failing for some other projects in [Sentry](https://sentry.is.canonical.com/canonical/jp-ubuntu-com/issues/11286/?query=is%3Aunresolved)

## QA
- Go to [Kubeflownews](https://github.com/canonical-web-and-design/kubeflow-news.com) project and use this version
- `dotrun test` and make sure all tests pass now
- To do a contrast test, see that if you use the previous version, it will fail with a `503` error 

## Issues
Fixes #141 