### PR TITLE
Remove fixed thumbnail height

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+6.2.1: Remove fixed thumbnail height
 6.2.0: Fix 503 instead of 404 status for articles not found
 6.1.1: Restructure; Use `image_template` for images processing
 6.1.0: Restructure; Add API wrapper; Remove helpers

--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -170,9 +170,7 @@ class BlogAPI(Wordpress):
                     and "source_url" in article["image"]
                 ):
                     article["image"]["rendered"] = self._apply_image_template(
-                        content=article["image"]["rendered"],
-                        width="330",
-                        height="177",
+                        content=article["image"]["rendered"], width="330",
                     )
 
         return article

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.2.0",
+    version="6.2.1",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -102,7 +102,7 @@ class TestBlueprint(VCRTestCase):
             if image is not None:
                 self.assertIn(
                     "https://res.cloudinary.com/canonical/image/fetch/"
-                    "f_auto,q_auto,fl_sanitize,w_330,h_177/"
+                    "f_auto,q_auto,fl_sanitize,w_330/"
                     "https://ubuntu.com/wp-content/uploads",
                     image.get("src"),
                 )
@@ -119,7 +119,7 @@ class TestBlueprint(VCRTestCase):
             if image is not None:
                 self.assertIn(
                     "https://res.cloudinary.com/canonical/image/fetch/"
-                    "f_auto,q_auto,fl_sanitize,w_330,h_177/"
+                    "f_auto,q_auto,fl_sanitize,w_330/"
                     "https://ubuntu.com/wp-content/uploads",
                     image.get("src"),
                 )


### PR DESCRIPTION
Prevent thumbnails stretching if image does not meet the right dimensions.

## QA

Go to: https://snapcraft-io-3000.demos.haus

Thumbnails should look just like on https://snapcraft.io/blog

The images will not look like this:
![image](https://user-images.githubusercontent.com/6387619/89645391-9cd16100-d8b1-11ea-8c83-56837fec1f88.png)
