### PR TITLE
Add e sharpen

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+6.2.5: Accommodate `e_sharpen` images
 6.2.4: Skip images with relative src path
 6.2.3: Skip images without src
 6.2.2: Fix bug with percent width

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.2.4",
+    version="6.2.5",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_blog_api.py
+++ b/tests/test_blog_api.py
@@ -52,7 +52,7 @@ class TestBlogAPI(VCRTestCase):
 
         self.assertIn(
             'src="https://res.cloudinary.com/canonical/image/fetch/f_auto,'
-            "q_auto,fl_sanitize,w_720/https://ubuntu.com"
+            "q_auto,fl_sanitize,e_sharpen,w_720/https://ubuntu.com"
             '/wp-content/uploads/2e4c/dell-xps-2004.jpg"',
             article["content"]["rendered"],
         )
@@ -69,7 +69,8 @@ class TestBlogAPI(VCRTestCase):
 
         self.assertIn(
             'src="https://res.cloudinary.com/canonical/image/fetch/f_auto,'
-            "q_auto,fl_sanitize,w_266,h_286/https://lh5.googleusercontent.com/"
+            "q_auto,fl_sanitize,e_sharpen,w_266,h_286/"
+            "https://lh5.googleusercontent.com/"
             "PKCTzU1ENAow2PDqhPo-K6drMTKwQduAAqKNUbHWVnJmmQXjI8GsXgSQhsVg6Q-"
             "0vZrKRCFNUxYvG1iIDVQ3MSTzgx-"
             'UWtGlLR6lgZQWcEt0P967bjqQCePnSJXOd3FWVjo0hzTG"',
@@ -88,12 +89,12 @@ class TestBlogAPI(VCRTestCase):
 
         self.assertNotIn(
             'src="https://res.cloudinary.com/canonical/image/fetch/'
-            "f_auto,q_auto,fl_sanitize,w_100%",
+            "f_auto,q_auto,fl_sanitize,e_sharpen,w_100%",
             article["content"]["rendered"],
         )
         self.assertIn(
             'src="https://res.cloudinary.com/canonical/image/fetch/'
-            "f_auto,q_auto,fl_sanitize,w_720",
+            "f_auto,q_auto,fl_sanitize,e_sharpen,w_720",
             article["content"]["rendered"],
         )
 

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -59,7 +59,7 @@ class TestBlueprint(VCRTestCase):
 
         image_src = (
             "src=&#34;https://res.cloudinary.com/canonical/image/fetch/"
-            "f_auto,q_auto,fl_sanitize,w_720/"
+            "f_auto,q_auto,fl_sanitize,e_sharpen,w_720/"
             "https://ubuntu.com/wp-content/uploads/2e4c/dell-xps-2004.jpg&#34;"
         )
 
@@ -115,7 +115,7 @@ class TestBlueprint(VCRTestCase):
             if image is not None:
                 self.assertIn(
                     "https://res.cloudinary.com/canonical/image/fetch/"
-                    "f_auto,q_auto,fl_sanitize,w_330/"
+                    "f_auto,q_auto,fl_sanitize,e_sharpen,w_330/"
                     "https://ubuntu.com/wp-content/uploads",
                     image.get("src"),
                 )
@@ -132,7 +132,7 @@ class TestBlueprint(VCRTestCase):
             if image is not None:
                 self.assertIn(
                     "https://res.cloudinary.com/canonical/image/fetch/"
-                    "f_auto,q_auto,fl_sanitize,w_330/"
+                    "f_auto,q_auto,fl_sanitize,e_sharpen,w_330/"
                     "https://ubuntu.com/wp-content/uploads",
                     image.get("src"),
                 )


### PR DESCRIPTION
Fix tests to accommodate the image-template changes that add `e_sharpen` to the list of flags on Cloudinary.