### PR TITLE
Make e_sharpen only for thumbnails

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+6.3.1: Make e_sharpen only for thumbnails
 6.3.0: Add thumbnail settings
 6.2.6: Fix `NotFoundError` errors
 6.2.5: Accommodate `e_sharpen` images

--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -178,6 +178,7 @@ class BlogAPI(Wordpress):
                         content=article["image"]["rendered"],
                         width=self.thumbnail_width,
                         height=self.thumbnail_height,
+                        use_e_sharpen=True,
                     )
 
         return article
@@ -214,7 +215,9 @@ class BlogAPI(Wordpress):
 
         return date(1900, month_index, 1).strftime("%B")
 
-    def _apply_image_template(self, content, width, height=None):
+    def _apply_image_template(
+        self, content, width, height=None, use_e_sharpen=False
+    ):
         """Apply image template to the img tags
 
         :param content: String to replace url
@@ -251,6 +254,7 @@ class BlogAPI(Wordpress):
                     height=img_height or height,
                     hi_def=True,
                     fill=True,
+                    e_sharpen=use_e_sharpen,
                     loading="lazy",
                 ),
                 "html.parser",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.3.0",
+    version="6.3.1",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_blog_api.py
+++ b/tests/test_blog_api.py
@@ -52,7 +52,7 @@ class TestBlogAPI(VCRTestCase):
 
         self.assertIn(
             'src="https://res.cloudinary.com/canonical/image/fetch/f_auto,'
-            "q_auto,fl_sanitize,e_sharpen,c_fill,w_720/https://ubuntu.com"
+            "q_auto,fl_sanitize,c_fill,w_720/https://ubuntu.com"
             '/wp-content/uploads/2e4c/dell-xps-2004.jpg"',
             article["content"]["rendered"],
         )
@@ -69,7 +69,7 @@ class TestBlogAPI(VCRTestCase):
 
         self.assertIn(
             'src="https://res.cloudinary.com/canonical/image/fetch/f_auto,'
-            "q_auto,fl_sanitize,e_sharpen,c_fill,w_266,h_286/"
+            "q_auto,fl_sanitize,c_fill,w_266,h_286/"
             "https://lh5.googleusercontent.com/"
             "PKCTzU1ENAow2PDqhPo-K6drMTKwQduAAqKNUbHWVnJmmQXjI8GsXgSQhsVg6Q-"
             "0vZrKRCFNUxYvG1iIDVQ3MSTzgx-"
@@ -89,12 +89,12 @@ class TestBlogAPI(VCRTestCase):
 
         self.assertNotIn(
             'src="https://res.cloudinary.com/canonical/image/fetch/'
-            "f_auto,q_auto,fl_sanitize,e_sharpen,c_fill,w_100%",
+            "f_auto,q_auto,fl_sanitize,c_fill,w_100%",
             article["content"]["rendered"],
         )
         self.assertIn(
             'src="https://res.cloudinary.com/canonical/image/fetch/'
-            "f_auto,q_auto,fl_sanitize,e_sharpen,c_fill,w_720",
+            "f_auto,q_auto,fl_sanitize,c_fill,w_720",
             article["content"]["rendered"],
         )
 

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -64,7 +64,7 @@ class TestBlueprint(VCRTestCase):
 
         image_src = (
             "src=&#34;https://res.cloudinary.com/canonical/image/fetch/"
-            "f_auto,q_auto,fl_sanitize,e_sharpen,c_fill,w_720/"
+            "f_auto,q_auto,fl_sanitize,c_fill,w_720/"
             "https://ubuntu.com/wp-content/uploads/2e4c/dell-xps-2004.jpg&#34;"
         )
 


### PR DESCRIPTION
Make `e_sharpen` optional. Only blog thumbnails need it. Other images might loose quality if sharpened.

## QA
Go to https://ubuntu-com-8409.demos.haus/blog
Inspect element a thumbnail. You will see the `e_sharpen` setting on the image.

Go to an article:
https://ubuntu-com-8409.demos.haus/blog/lenovo-expand-enterprise-desktop-range-preinstalled-with-ubuntu
Inspect element the image. It will not have `e_sharpen`

Go to the homepage:
https://ubuntu-com-8409.demos.haus
Inspect element the spotify logo. It will not have the `e_sharpen`. Logo will look good.