### PR TITLE
Add inclusive naming action

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,3 +49,17 @@ jobs:
 
       - name: Test Python
         run: python3 setup.py test
+        
+  check-inclusive-naming:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check inclusive naming
+        uses: canonical-web-and-design/inclusive-naming@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          fail-on-error: true

--- a/tests/cassettes/TestBlueprint.test_author.yaml
+++ b/tests/cassettes/TestBlueprint.test_author.yaml
@@ -465,7 +465,7 @@ interactions:
         italic\">It should also have been :+1:d by at least 2 team members<\/li>\n<li
         style=\"font-style: italic\">It should have been open for at least 24 hours<\/li>\n<\/ul>\n<p>Once
         it is merged, it should be brought up in the next relevant team meeting to
-        ensure the whole team is aware of the change.<\/p><\/blockquote>\n<p><a href=\"https:\/\/github.com\/canonical-webteam\/practices\/blob\/master\/CONTRIBUTING.md\">These
+        ensure the whole team is aware of the change.<\/p><\/blockquote>\n<p><a href=\"https:\/\/github.com\/canonical-webteam\/practices\/blob\/main\/CONTRIBUTING.md\">These
         rules<\/a> are to reinforce the idea of working slowly. Much more than speed,
         it is important that changes are carefully considered and agreed by everyone.<\/p>\n<ul>\n<li>New
         changes can be suggested by anyone as <a href=\"https:\/\/github.com\/canonical-webteam\/practices\/pulls\">public

--- a/tests/cassettes/TestBlueprint.test_author_feed.yaml
+++ b/tests/cassettes/TestBlueprint.test_author_feed.yaml
@@ -466,7 +466,7 @@ interactions:
         italic\">It should also have been :+1:d by at least 2 team members<\/li>\n<li
         style=\"font-style: italic\">It should have been open for at least 24 hours<\/li>\n<\/ul>\n<p>Once
         it is merged, it should be brought up in the next relevant team meeting to
-        ensure the whole team is aware of the change.<\/p><\/blockquote>\n<p><a href=\"https:\/\/github.com\/canonical-webteam\/practices\/blob\/master\/CONTRIBUTING.md\">These
+        ensure the whole team is aware of the change.<\/p><\/blockquote>\n<p><a href=\"https:\/\/github.com\/canonical-webteam\/practices\/blob\/main\/CONTRIBUTING.md\">These
         rules<\/a> are to reinforce the idea of working slowly. Much more than speed,
         it is important that changes are carefully considered and agreed by everyone.<\/p>\n<ul>\n<li>New
         changes can be suggested by anyone as <a href=\"https:\/\/github.com\/canonical-webteam\/practices\/pulls\">public


### PR DESCRIPTION
## Work done

- Adds inclusive naming github action
- Replaces key non-inclusive language

## TODO

- Rename 'master' to 'main'

## QA

- Check github action works
- Check language changes make lexical sense

## Issue

- Fixes: https://github.com/canonical-web-and-design/web-squad/issues/4499