### PR TITLE
[WD-24186] feat: Blog images can now pull their width and height from css styles

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+6.5.0: Blog Images can now pull their width and height from css styles
 6.4.6: Added `per_page` in `get_archives` endpoint
 6.4.5: Added `total_posts` in `get_tag` endpoint and `per_page` in `get_tag`, `get_author` and `get_index` endpoints
 6.4.4: Reverted changes made in v6.4.2

--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -242,6 +242,7 @@ class BlogAPI(Wordpress):
             if not image.get("src") or "http" not in image.get("src"):
                 continue
 
+            # Try to get width from the 'width' attribute
             img_width = (
                 image.get("width")
                 if image.get("width") is not None
@@ -249,12 +250,24 @@ class BlogAPI(Wordpress):
                 else None
             )
 
+            # If not found, try to get width from the 'style' attribute
+            if img_width is None and image.has_attr("style"):
+                match = re.search(r"width\s*:\s*(\d+)px", image["style"])
+                if match:
+                    img_width = match.group(1)
+
             img_height = (
                 image.get("height")
                 if image.get("height") is not None
                 and image.get("height").isdigit()
                 else None
             )
+
+            # If not found, try to get height from the 'style' attribute
+            if img_height is None and image.has_attr("style"):
+                match = re.search(r"height\s*:\s*(\d+)px", image["style"])
+                if match:
+                    img_height = match.group(1)
 
             new_image = BeautifulSoup(
                 image_template(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.4.6",
+    version="6.5.0",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Done

- Blog images pull width and height from css styles

## QA

- Check out this [demo](https://ubuntu-com-15393.demos.haus/blog/linux-foundation-openstack)
- Verify the blog images have 500px width 
- Please also approve [this demo PR](https://github.com/canonical/ubuntu.com/pull/15393)

## Issue / Card

Fixes #[WD-24186](https://warthogs.atlassian.net/browse/WD-24186)

[WD-24186]: https://warthogs.atlassian.net/browse/WD-24186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ