### PR TITLE
🔧 Handle invalid page number gracefully in get_articles

### DIFF
--- a/canonicalwebteam/blog/wordpress.py
+++ b/canonicalwebteam/blog/wordpress.py
@@ -45,7 +45,13 @@ class Wordpress:
             self.session.headers.update({"Accept": "application/json"})
 
     def request(
-        self, endpoint, params={}, method="get", embed=True, fields=None
+        self,
+        endpoint,
+        params={},
+        method="get",
+        embed=True,
+        fields=None,
+        raise_for_status=True,
     ):
         """
         Build url to fetch articles from Wordpress api
@@ -82,7 +88,8 @@ class Wordpress:
         response = self.session.request(
             method, f"{self.api_url}/{endpoint}?{query}"
         )
-        response.raise_for_status()
+        if raise_for_status:
+            response.raise_for_status()
 
         return response
 
@@ -145,7 +152,19 @@ class Wordpress:
                 "status": status,
             },
             fields=(fields if fields else DEFAULT_POST_FIELDS),
+            raise_for_status=False,
         )
+
+        # Gracefully handle invalid page number (WordPress REST API 400)
+        if response.status_code == 400:
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = {}
+            if payload.get("code") == "rest_post_invalid_page_number":
+                return ([], {"total_pages": "0", "total_posts": "0"})
+            # Different 400 error; propagate
+            response.raise_for_status()
         total_pages = response.headers.get("X-WP-TotalPages")
         total_posts = response.headers.get("X-WP-Total")
 

--- a/tests/test_wordpress.py
+++ b/tests/test_wordpress.py
@@ -96,12 +96,18 @@ class TestWordpress(VCRTestCase):
     def test_get_articles_invalid_page_number(self):
         mock_response = Mock()
         mock_response.status_code = 400
-        mock_response.json.return_value = {"code": "rest_post_invalid_page_number"}
+        mock_response.json.return_value = {
+            "code": "rest_post_invalid_page_number"
+        }
         mock_response.headers = {}
         mock_response.raise_for_status.side_effect = requests.HTTPError()
-        mock_response.url = "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?page=999999"
+        mock_response.url = (
+            "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?page=999999"
+        )
 
-        with patch.object(self.api.session, "request", return_value=mock_response):
+        with patch.object(
+            self.api.session, "request", return_value=mock_response
+        ):
             articles, metadata = self.api.get_articles(page=999999)
 
         self.assertEqual(articles, [])

--- a/tests/test_wordpress.py
+++ b/tests/test_wordpress.py
@@ -1,6 +1,7 @@
 # Packages
 import requests
 from vcr_unittest import VCRTestCase
+from unittest.mock import Mock, patch
 
 # Local
 from canonicalwebteam.blog import Wordpress
@@ -91,3 +92,18 @@ class TestWordpress(VCRTestCase):
         group = self.api.get_group_by_slug(slug="ai")
         self.assertEqual(group["name"], "AI")
         self.assertEqual(group["id"], 3367)
+
+    def test_get_articles_invalid_page_number(self):
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.json.return_value = {"code": "rest_post_invalid_page_number"}
+        mock_response.headers = {}
+        mock_response.raise_for_status.side_effect = requests.HTTPError()
+        mock_response.url = "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?page=999999"
+
+        with patch.object(self.api.session, "request", return_value=mock_response):
+            articles, metadata = self.api.get_articles(page=999999)
+
+        self.assertEqual(articles, [])
+        self.assertEqual(metadata["total_pages"], "0")
+        self.assertEqual(metadata["total_posts"], "0")


### PR DESCRIPTION
# Handle invalid page number gracefully in get_articles

Add error handling for invalid page number requests to WordPress API. 
When receiving a 400 error with code "rest_post_invalid_page_number", return empty results instead of raising an exception. 
This improves user experience when paginating beyond available pages.

### QA steps
- Events page
Check https://ubuntu-com-15809.demos.haus/blog/tag/event
See that it loads okay
- A paginated page (last page)
Check page 11 - https://ubuntu-com-15809.demos.haus/blog/tag/event?page=11
which is the last page. See that it loads okay.
- A page with a paginated number beyond the total articles count
Check page 12 (a page above the last page) - https://ubuntu-com-15809.demos.haus/blog/tag/event?page=12
see that it shows empty page.

Compare the above behaviour with production
- Events page: https://ubuntu.com/blog/tag/event
- Events paginated page: https://ubuntu.com/blog/tag/event?page=11
- Event invalid paginated page: https://ubuntu.com/blog/tag/event?page=12