### PR TITLE
🔧 Handle upstream errors from WordPress API

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,4 @@
-6.7.1: Harden blueprint WordPress API error handling (map 400 pagination→404, 404→NotFound, timeouts→504, connection errors→503).
+6.8.0: Harden blueprint WordPress API error handling (map 400 pagination→404, 404→NotFound, timeouts→504, connection errors→503).
 6.7.0: Replace `_embed` on resource types (tags, group, topic) and add `_fields` filter for smaller responses for lists.
 6.6.0: Allow passing of 'status' when fetching blogs & added ability to add credentials 
 6.5.0: Blog Images can now pull their width and height from css styles

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+6.7.1: Harden blueprint WordPress API error handling (map 400 pagination→404, 404→NotFound, timeouts→504, connection errors→503).
 6.7.0: Replace `_embed` on resource types (tags, group, topic) and add `_fields` filter for smaller responses for lists.
 6.6.0: Allow passing of 'status' when fetching blogs & added ability to add credentials 
 6.5.0: Blog Images can now pull their width and height from css styles

--- a/canonicalwebteam/blog/blueprint.py
+++ b/canonicalwebteam/blog/blueprint.py
@@ -1,7 +1,11 @@
 # Packages
 import flask
 import requests
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import (
+    NotFound,
+    ServiceUnavailable,
+    GatewayTimeout,
+)
 
 
 def build_blueprint(blog_views):
@@ -170,29 +174,82 @@ def build_blueprint(blog_views):
 
         return flask.render_template("blog/tag.html", **context)
 
+    # Error handling
     @blueprint.app_errorhandler(requests.exceptions.HTTPError)
     def handle_http_error(error):
         """
         Handle HTTP errors from WordPress API requests.
-        Converts 400 client errors to 404 to provide a consistent
-        user experience when resources are not found or unavailable.
+
+        - Maps specific WP API client errors to 404 to preserve UX
+        - Logs parsing and format issues but preserves original behavior
+        - Falls back to re-raising the error for non-mapped cases
         """
         response = getattr(error, "response", None)
+
+        # If the HTTPError includes a Response, inspect it for known cases
         if response is not None:
-            status = response.status_code
+            status = getattr(response, "status_code", None)
+
+            # Convert known pagination error to 404
             if status == 400:
                 try:
-                    error_data = response.json()
+                    # Only attempt parsing when Content-Type indicates JSON
+                    content_type = (response.headers or {}).get(
+                        "Content-Type", ""
+                    )
+                    if "json" in content_type:
+                        error_data = response.json()
+                    else:
+                        error_data = {}
+
                     # page number is higher than available pagination
                     if (
-                        error_data.get("code")
+                        isinstance(error_data, dict)
+                        and error_data.get("code")
                         == "rest_post_invalid_page_number"
                     ):
+                        flask.current_app.logger.warning(
+                            "Mapping WP API 400 invalid_page_number to 404"
+                        )
                         return flask.current_app.handle_http_exception(
                             NotFound()
                         )
-                except (ValueError, KeyError):
-                    pass
+                except (
+                    ValueError,
+                    KeyError,
+                    TypeError,
+                    AttributeError,
+                ) as parse_err:
+                    # Log, but fall through to default behavior (re-raise)
+                    flask.current_app.logger.debug(
+                        f"Failed to parse WP API error JSON: {parse_err}"
+                    )
+
+            # If WP API returns 404, propagate as NotFound for consistency
+            if status == 404:
+                flask.current_app.logger.info("Mapping WP API 404 to NotFound")
+                return flask.current_app.handle_http_exception(NotFound())
+
+        # No actionable mapping – preserve original behavior
+        flask.current_app.logger.error(
+            "Unmapped HTTPError from WP API; re-raising", exc_info=error
+        )
         raise error
+
+    @blueprint.app_errorhandler(requests.exceptions.Timeout)
+    def handle_timeout(error):
+        """Map network timeouts to Gateway Timeout (504)."""
+        flask.current_app.logger.error(
+            "WordPress API request timed out", exc_info=error
+        )
+        return flask.current_app.handle_http_exception(GatewayTimeout())
+
+    @blueprint.app_errorhandler(requests.exceptions.ConnectionError)
+    def handle_connection_error(error):
+        """Map connection errors to Service Unavailable (503)."""
+        flask.current_app.logger.error(
+            "WordPress API connection error", exc_info=error
+        )
+        return flask.current_app.handle_http_exception(ServiceUnavailable())
 
     return blueprint

--- a/canonicalwebteam/blog/blueprint.py
+++ b/canonicalwebteam/blog/blueprint.py
@@ -1,6 +1,7 @@
 # Packages
 import flask
 import requests
+from werkzeug.exceptions import NotFound
 
 
 def build_blueprint(blog_views):
@@ -169,16 +170,29 @@ def build_blueprint(blog_views):
 
         return flask.render_template("blog/tag.html", **context)
 
-    @blueprint.errorhandler(requests.exceptions.HTTPError)
+    @blueprint.app_errorhandler(requests.exceptions.HTTPError)
     def handle_http_error(error):
+        """
+        Handle HTTP errors from WordPress API requests.
+        Converts 400 client errors to 404 to provide a consistent
+        user experience when resources are not found or unavailable.
+        """
         response = getattr(error, "response", None)
-        if response is not None and response.status_code == 400:
-            try:
-                payload = response.json()
-            except Exception:
-                payload = {}
-            if payload.get("code") == "rest_post_invalid_page_number":
-                flask.abort(404)
+        if response is not None:
+            status = response.status_code
+            if status == 400:
+                try:
+                    error_data = response.json()
+                    # page number is higher than available pagination
+                    if (
+                        error_data.get("code")
+                        == "rest_post_invalid_page_number"
+                    ):
+                        return flask.current_app.handle_http_exception(
+                            NotFound()
+                        )
+                except (ValueError, KeyError):
+                    pass
         raise error
 
     return blueprint

--- a/canonicalwebteam/blog/blueprint.py
+++ b/canonicalwebteam/blog/blueprint.py
@@ -1,5 +1,6 @@
 # Packages
 import flask
+import requests
 
 
 def build_blueprint(blog_views):
@@ -167,5 +168,17 @@ def build_blueprint(blog_views):
             flask.abort(404)
 
         return flask.render_template("blog/tag.html", **context)
+
+    @blueprint.errorhandler(requests.exceptions.HTTPError)
+    def handle_http_error(error):
+        response = getattr(error, "response", None)
+        if response is not None and response.status_code == 400:
+            try:
+                payload = response.json()
+            except Exception:
+                payload = {}
+            if payload.get("code") == "rest_post_invalid_page_number":
+                flask.abort(404)
+        raise error
 
     return blueprint

--- a/canonicalwebteam/blog/blueprint.py
+++ b/canonicalwebteam/blog/blueprint.py
@@ -202,7 +202,7 @@ def build_blueprint(blog_views):
                     else:
                         error_data = {}
 
-                    # page number is higher than available pagination
+                    # Page number is higher than available pagination
                     if (
                         isinstance(error_data, dict)
                         and error_data.get("code")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.7.0",
+    version="6.7.1",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.7.1",
+    version="6.8.0",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_blueprint_error_handlers.py
+++ b/tests/test_blueprint_error_handlers.py
@@ -1,0 +1,85 @@
+import flask
+import requests
+import unittest
+from flask_reggie import Reggie
+
+from canonicalwebteam.blog import build_blueprint
+
+
+class StubViews:
+    def get_tag(self, slug, page=1):
+        if slug == "invalid-page":
+            resp = requests.Response()
+            resp.status_code = 400
+            resp._content = b'{"code":"rest_post_invalid_page_number"}'
+            resp.headers = {"Content-Type": "application/json"}
+            raise requests.exceptions.HTTPError(response=resp)
+        if slug == "bad-json":
+            resp = requests.Response()
+            resp.status_code = 400
+            resp._content = b"not json"
+            resp.headers = {"Content-Type": "text/plain"}
+            raise requests.exceptions.HTTPError(response=resp)
+        if slug == "no-response":
+            raise requests.exceptions.HTTPError(response=None)
+        if slug == "timeout":
+            raise requests.exceptions.Timeout()
+        if slug == "conn":
+            raise requests.exceptions.ConnectionError()
+        if slug == "http404":
+            resp = requests.Response()
+            resp.status_code = 404
+            resp._content = b"{}"
+            resp.headers = {"Content-Type": "application/json"}
+            raise requests.exceptions.HTTPError(response=resp)
+        if slug == "reqexc":
+            raise requests.exceptions.RequestException("generic")
+        # default: return some context to render
+        return {
+            "title": "Test",
+            "articles": [],
+            "current_page": page,
+            "total_pages": 1,
+            "total_posts": 0,
+            "blog_title": "Test",
+            "tag": {"id": 1, "name": "t", "slug": "t"},
+        }
+
+
+class TestBlueprintErrorHandlers(unittest.TestCase):
+    def setUp(self):
+        app = flask.Flask("test")
+        Reggie().init_app(app)
+        blog = build_blueprint(blog_views=StubViews())
+        app.register_blueprint(blog, url_prefix="/")
+        # Disable exception propagation so we can assert on status codes
+        app.testing = False
+        self.client = app.test_client()
+
+    def test_invalid_page_number_maps_to_404(self):
+        resp = self.client.get("/tag/invalid-page")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_bad_json_unmapped_results_in_500(self):
+        resp = self.client.get("/tag/bad-json")
+        self.assertEqual(resp.status_code, 500)
+
+    def test_no_response_re_raises_results_in_500(self):
+        resp = self.client.get("/tag/no-response")
+        self.assertEqual(resp.status_code, 500)
+
+    def test_timeout_returns_504(self):
+        resp = self.client.get("/tag/timeout")
+        self.assertEqual(resp.status_code, 504)
+
+    def test_connection_error_returns_503(self):
+        resp = self.client.get("/tag/conn")
+        self.assertEqual(resp.status_code, 503)
+
+    def test_http_404_maps_to_404(self):
+        resp = self.client.get("/tag/http404")
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Unhandled or poorly handled upstream errors from WordPress API requests led to inconsistent client responses and occasional 500s:
- 400 responses with non-JSON bodies caused .json() parsing failures.
- HTTPError 404 from upstream was not consistently surfaced as a 404 Not Found .

This improves user experience when paginating beyond available pages.

### QA steps
- Events page
Check https://canonical-com-2051.demos.haus/blog/tag/event
See that it loads okay
- A paginated page (last page)
Check page 11 - https://canonical-com-2051.demos.haus/blog/tag/event?page=11
which is the last page. See that it loads okay.
- A page with a paginated number beyond the total articles count
Check page 12 (a page above the last page) - https://canonical-com-2051.demos.haus/blog/tag/event?page=12
see that it shows a 404 page and not a 500 server error page.

Compare the above behaviour with production
- Events page: https://canonical.com/blog/tag/event
- Events paginated page: https://canonical.com/blog/tag/event?page=11
- Event invalid paginated page: https://canonical.com/blog/tag/event?page=12

### Ticket
https://warthogs.atlassian.net/browse/WD-31091