### PR TITLE
Validate image URLs before processing

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+6.8.2: Adds a URL validity check in _apply_image_template before calling image_template(...). Skips any img with an invalid URL (non-HTTP(S) or missing host) to prevent errors from bad links.
 6.8.1: Sanitize slug input.
 6.8.0: Harden blueprint WordPress API error handling (map 400 pagination→404, 404→NotFound, timeouts→504, connection errors→503).
 6.7.0: Replace `_embed` on resource types (tags, group, topic) and add `_fields` filter for smaller responses for lists.

--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -261,7 +261,7 @@ class BlogAPI(Wordpress):
         for image in soup.findAll("img"):
             image_url = image.get("src")
 
-            if not image_url or "http" not in image_url:
+            if not image_url:
                 continue
 
             parsed = urlparse(image_url)

--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -3,6 +3,7 @@ import re
 import html
 from datetime import date
 from datetime import datetime
+from urllib.parse import urlparse
 
 # Packages
 from bs4 import BeautifulSoup
@@ -258,7 +259,13 @@ class BlogAPI(Wordpress):
 
         soup = BeautifulSoup(content, "html.parser")
         for image in soup.findAll("img"):
-            if not image.get("src") or "http" not in image.get("src"):
+            image_url = image.get("src")
+
+            if not image_url or "http" not in image_url:
+                continue
+
+            parsed = urlparse(image_url)
+            if parsed.scheme not in ["http", "https"] or not parsed.netloc:
                 continue
 
             # Try to get width from the 'width' attribute
@@ -290,7 +297,7 @@ class BlogAPI(Wordpress):
 
             new_image = BeautifulSoup(
                 image_template(
-                    url=image.get("src"),
+                    url=image_url,
                     alt="",
                     width=img_width or width,
                     height=img_height or height,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.8.1",
+    version="6.8.2",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Done
Ensure image URLs have valid scheme and netloc before attempting to process them to prevent potential errors.
- Adds a URL validity check in _apply_image_template before calling image_template(...) .
- Skips any img with an invalid URL (non-HTTP(S) or missing host) to prevent errors from bad links.

Validating with `urlparse` ensures scheme is http / https and netloc is present, catching common invalid cases early and avoiding exceptions in image_template .

## QA

- Check out this blog post with invalid image URL: 
- https://canonical-com-2072.demos.haus/blog/everything-you-need-to-know-about-fips-140-3-on-ubuntu-videos
- Check that the page loads
- compare that to production
- https://canonical.com/blog/everything-you-need-to-know-about-fips-140-3-on-ubuntu-videos

## Ticket
https://warthogs.atlassian.net/browse/WD-31318