### PR TITLE
ci: add release drafter configuration and workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,8 @@
+change-template: "$TITLE (#$NUMBER)"
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  ## Changes
+  $CHANGES
+  ## This release was made possible by the following contributors:
+  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,7 +1,6 @@
 name: Release Drafter
 
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,6 +1,7 @@
 name: Release Drafter
 
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Get version number from setup.py 2
-        id: py-version
+      - name: Get version number from setup.py
+        id: version
         run: printf "version=%s\n" "$(grep '^[[:blank:]]*version' setup.py | cut -d'"' -f 2)" >> "$GITHUB_OUTPUT"
       - uses: release-drafter/release-drafter@v6
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,9 @@ jobs:
         run: |
           set -e
           echo "version=$(grep '^[[:blank:]]*version' setup.py | cut -d'"' -f 2)" >> "$GITHUB_OUTPUT"
+      - name: Get version number from setup.py 2
+        id: py-version
+        run: printf "version=%s\n" "$(grep '^[[:blank:]]*version' setup.py | cut -d'\"' -f 2)" >> "$GITHUB_OUTPUT"
       - uses: release-drafter/release-drafter@v6
         with:
           tag: "${{ steps.version.outputs.version }}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,7 +21,7 @@ jobs:
           echo "version=$(grep '^[[:blank:]]*version' setup.py | cut -d'"' -f 2)" >> "$GITHUB_OUTPUT"
       - name: Get version number from setup.py 2
         id: py-version
-        run: printf "version=%s\n" "$(grep '^[[:blank:]]*version' setup.py | cut -d'\"' -f 2)" >> "$GITHUB_OUTPUT"
+        run: printf "version=%s\n" "$(grep '^[[:blank:]]*version' setup.py | cut -d'"' -f 2)" >> "$GITHUB_OUTPUT"
       - uses: release-drafter/release-drafter@v6
         with:
           tag: "${{ steps.version.outputs.version }}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - setup.py
 
 jobs:
   create-release:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,12 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Get version number from setup.py
-        id: version
-        shell: bash
-        run: |
-          set -e
-          echo "version=$(grep '^[[:blank:]]*version' setup.py | cut -d'"' -f 2)" >> "$GITHUB_OUTPUT"
       - name: Get version number from setup.py 2
         id: py-version
         run: printf "version=%s\n" "$(grep '^[[:blank:]]*version' setup.py | cut -d'"' -f 2)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,27 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - setup.py
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get version number from setup.py
+        id: version
+        shell: bash
+        run: |
+          set -e
+          echo "version=$(grep '^[[:blank:]]*version' setup.py | cut -d'"' -f 2)" >> "$GITHUB_OUTPUT"
+      - uses: release-drafter/release-drafter@v6
+        with:
+          tag: "${{ steps.version.outputs.version }}"
+          version: "${{ steps.version.outputs.version }}"
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow automatically publishes releases and tags them with the version from setup.py when changes are pushed to main branch via PRs.

Same release workflow as https://github.com/canonical/canonicalwebteam.discourse/blob/main/.github/workflows/release-drafter.yml

ticket: https://warthogs.atlassian.net/browse/WD-31464