### PR TITLE
fix(WD-32593): Wordpress API returning 404 for articles with special characters in slug

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+6.8.3: Fix wordpress API returning 404 for article slugs containing special characters
 6.8.2: Adds a URL validity check in _apply_image_template before calling image_template(...). Skips any img with an invalid URL (non-HTTP(S) or missing host) to prevent errors from bad links.
 6.8.1: Sanitize slug input.
 6.8.0: Harden blueprint WordPress API error handling (map 400 pagination→404, 404→NotFound, timeouts→504, connection errors→503).

--- a/canonicalwebteam/blog/wordpress.py
+++ b/canonicalwebteam/blog/wordpress.py
@@ -308,10 +308,7 @@ class Wordpress:
                 break
             slug = decoded
 
-        ascii_lower = str.maketrans(
-            ascii_uppercase,
-            ascii_lowercase
-        )
+        ascii_lower = str.maketrans(ascii_uppercase, ascii_lowercase)
 
         slug = slug.translate(ascii_lower)
 

--- a/canonicalwebteam/blog/wordpress.py
+++ b/canonicalwebteam/blog/wordpress.py
@@ -7,7 +7,8 @@ from .constants import (
 )
 import base64
 import re
-from urllib.parse import urlencode, unquote
+from urllib.parse import urlencode, unquote, quote
+from string import ascii_uppercase, ascii_lowercase
 
 
 class NotFoundError(Exception):
@@ -307,12 +308,18 @@ class Wordpress:
                 break
             slug = decoded
 
-        slug = slug.lower()
+        ascii_lower = str.maketrans(
+            ascii_uppercase,
+            ascii_lowercase
+        )
+
+        slug = slug.translate(ascii_lower)
 
         # Only keep letters, numbers, hyphens, and underscores
-        cleaned_slug = re.sub(r"[^a-z0-9-_]", "", slug)
+        # Allow the symbols, like copyright, trademark, and registered
+        cleaned_slug = re.sub(r"[^a-z0-9-_\u2460-\u24ff]", "", slug)
 
         # Cleanup any repeated hyphens or leading/trailing hyphens
         cleaned_slug = re.sub(r"-+", "-", cleaned_slug).strip("-")
 
-        return cleaned_slug
+        return quote(cleaned_slug)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.8.2",
+    version="6.8.3",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Done

- Modified sanitation function to allow WP API expected characters

## QA

- Visit [demo](https://ubuntu-com-15942.demos.haus/blog/tag/performance)
- Click at first article "Maximizing CPU efficiency and energy savings with IntelⓇ QuickAssist Technology on Ubuntu 24.04"
- Make sure it opens up
- Open some other blog articles and verify they work as expected too

## Issue

Fixes [WD-32082](https://warthogs.atlassian.net/browse/WD-32802)

[WD-32082]: https://warthogs.atlassian.net/browse/WD-32082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ