### PR TITLE
chore: Add request timeout (30s), retry logic for transient 5xx errors

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+6.8.4: Add request timeout (30s), retry logic for transient 5xx errors, and ChunkedEncodingError handler (502).
 6.8.3: Fix wordpress API returning 404 for article slugs containing special characters
 6.8.2: Adds a URL validity check in _apply_image_template before calling image_template(...). Skips any img with an invalid URL (non-HTTP(S) or missing host) to prevent errors from bad links.
 6.8.1: Sanitize slug input.

--- a/canonicalwebteam/blog/blueprint.py
+++ b/canonicalwebteam/blog/blueprint.py
@@ -2,6 +2,7 @@
 import flask
 import requests
 from werkzeug.exceptions import (
+    BadGateway,
     NotFound,
     ServiceUnavailable,
     GatewayTimeout,
@@ -251,5 +252,13 @@ def build_blueprint(blog_views):
             "WordPress API connection error", exc_info=error
         )
         return flask.current_app.handle_http_exception(ServiceUnavailable())
+
+    @blueprint.app_errorhandler(requests.exceptions.ChunkedEncodingError)
+    def handle_chunked_encoding_error(error):
+        """Map chunked encoding errors to Bad Gateway (502)."""
+        flask.current_app.logger.error(
+            "WordPress API chunked encoding error", exc_info=error
+        )
+        return flask.current_app.handle_http_exception(BadGateway())
 
     return blueprint

--- a/canonicalwebteam/blog/wordpress.py
+++ b/canonicalwebteam/blog/wordpress.py
@@ -1,17 +1,18 @@
-from .constants import (
-    CATEGORY_FIELDS,
-    TAG_FIELDS,
-    USER_FIELDS,
-    DEFAULT_POST_FIELDS,
-    POST_DETAILS_FIELDS,
-)
 import base64
 import re
-from urllib.parse import urlencode, unquote, quote
-from string import ascii_uppercase, ascii_lowercase
+from string import ascii_lowercase, ascii_uppercase
+from urllib.parse import quote, unquote, urlencode
 
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+
+from .constants import (
+    CATEGORY_FIELDS,
+    DEFAULT_POST_FIELDS,
+    POST_DETAILS_FIELDS,
+    TAG_FIELDS,
+    USER_FIELDS,
+)
 
 
 class NotFoundError(Exception):
@@ -45,9 +46,7 @@ class Wordpress:
             )
         # Encourage compressed responses for performance
         if "Accept-Encoding" not in self.session.headers:
-            self.session.headers.update(
-                {"Accept-Encoding": "gzip, deflate, br"}
-            )
+            self.session.headers.update({"Accept-Encoding": "gzip, deflate, br"})
         if "Accept" not in self.session.headers:
             self.session.headers.update({"Accept": "application/json"})
 
@@ -59,11 +58,8 @@ class Wordpress:
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self.session.mount("https://", adapter)
-        self.session.mount("http://", adapter)
 
-    def request(
-        self, endpoint, params={}, method="get", embed=True, fields=None
-    ):
+    def request(self, endpoint, params={}, method="get", embed=True, fields=None):
         """
         Build url to fetch articles from Wordpress api
         :param endpoint: The REST endpoint to fetch data from
@@ -207,9 +203,7 @@ class Wordpress:
             return {}
 
     def get_tag_by_id(self, id):
-        return self.request(
-            f"tags/{id}", embed=False, fields=TAG_FIELDS
-        ).json()
+        return self.request(f"tags/{id}", embed=False, fields=TAG_FIELDS).json()
 
     def get_tag_by_slug(self, slug):
         sanitized_slug = self._sanitize_slug_decode(slug)

--- a/canonicalwebteam/blog/wordpress.py
+++ b/canonicalwebteam/blog/wordpress.py
@@ -46,7 +46,9 @@ class Wordpress:
             )
         # Encourage compressed responses for performance
         if "Accept-Encoding" not in self.session.headers:
-            self.session.headers.update({"Accept-Encoding": "gzip, deflate, br"})
+            self.session.headers.update(
+                {"Accept-Encoding": "gzip, deflate, br"}
+            )
         if "Accept" not in self.session.headers:
             self.session.headers.update({"Accept": "application/json"})
 
@@ -59,7 +61,9 @@ class Wordpress:
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self.session.mount("https://", adapter)
 
-    def request(self, endpoint, params={}, method="get", embed=True, fields=None):
+    def request(
+        self, endpoint, params={}, method="get", embed=True, fields=None
+    ):
         """
         Build url to fetch articles from Wordpress api
         :param endpoint: The REST endpoint to fetch data from
@@ -203,7 +207,9 @@ class Wordpress:
             return {}
 
     def get_tag_by_id(self, id):
-        return self.request(f"tags/{id}", embed=False, fields=TAG_FIELDS).json()
+        return self.request(
+            f"tags/{id}", embed=False, fields=TAG_FIELDS
+        ).json()
 
     def get_tag_by_slug(self, slug):
         sanitized_slug = self._sanitize_slug_decode(slug)

--- a/canonicalwebteam/blog/wordpress.py
+++ b/canonicalwebteam/blog/wordpress.py
@@ -10,6 +10,9 @@ import re
 from urllib.parse import urlencode, unquote, quote
 from string import ascii_uppercase, ascii_lowercase
 
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
 
 class NotFoundError(Exception):
     pass
@@ -22,6 +25,7 @@ class Wordpress:
         api_url="https://admin.insights.ubuntu.com/wp-json/wp/v2",
         wordpress_username=None,
         wordpress_password=None,
+        timeout=30,
     ):
         """
         Wordpress API object, for making calls to the wordpress API
@@ -31,6 +35,7 @@ class Wordpress:
         self.api_url = api_url
         self.wordpress_username = wordpress_username
         self.wordpress_password = wordpress_password
+        self.timeout = timeout
 
         if self.wordpress_username and self.wordpress_password:
             creds = f"{self.wordpress_username}:{self.wordpress_password}"
@@ -45,6 +50,16 @@ class Wordpress:
             )
         if "Accept" not in self.session.headers:
             self.session.headers.update({"Accept": "application/json"})
+
+        # Configure retry logic for transient failures
+        retry_strategy = Retry(
+            total=3,
+            backoff_factor=1,
+            status_forcelist=[502, 503, 504],
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
 
     def request(
         self, endpoint, params={}, method="get", embed=True, fields=None
@@ -82,7 +97,7 @@ class Wordpress:
         query = urlencode(clean_params)
 
         response = self.session.request(
-            method, f"{self.api_url}/{endpoint}?{query}"
+            method, f"{self.api_url}/{endpoint}?{query}", timeout=self.timeout
         )
         response.raise_for_status()
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.8.3",
+    version="6.8.4",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Problem

The WordPress API client occasionally fails with ChunkedEncodingError: Response
   ended prematurely when fetching large payloads. This happens because:
  - No timeout configured, so requests can hang indefinitely
  - No retry mechanism for transient server errors
  - ChunkedEncodingError was unhandled, causing 500 errors

## Done
  - Add request timeout (30s) to prevent hanging connections on large payloads
  - Add retry logic (3 retries with exponential backoff) for transient 5xx errors
   (502, 503, 504)
  - Add error handler for ChunkedEncodingError that returns 502 Bad Gateway
  
  ## Issue
  https://canonical-ax.sentry.io/issues/88682441/?project=4510709886419024&query=is%3Aunresolved&referrer=issue-stream

https://warthogs.atlassian.net/browse/WD-33122
  
  ## QA
  Check that it loads okay 
ubuntu
  https://ubuntu-com-15976.demos.haus/blog
  https://ubuntu-com-15976.demos.haus/blog/feed
canonical
https://canonical-com-2200.demos.haus/blog