### PR TITLE
feat(blog): add tag mapping support for blog filtering

### DIFF
--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -17,7 +17,7 @@ class BlogAPI(Wordpress):
     def __init__(
         self,
         session,
-        api_url="https://admin.insights.ubuntu.com/wp-json/wp/v2",
+        api_url="https://staging-admin.insights.ubuntu.com/wp-json/wp/v2",
         use_image_template=True,
         thumbnail_width=330,
         thumbnail_height=185,
@@ -221,7 +221,7 @@ class BlogAPI(Wordpress):
         :returns: A string with converted urls
         """
 
-        url = "admin.insights.ubuntu.com/wp-content/uploads"
+        url = "staging-admin.insights.ubuntu.com/wp-content/uploads"
         new_url = "ubuntu.com/wp-content/uploads"
 
         return content.replace(url, new_url)

--- a/canonicalwebteam/blog/views.py
+++ b/canonicalwebteam/blog/views.py
@@ -413,8 +413,7 @@ class BlogViews:
         if not self.tag_mapping:
             return tag_ids
         return [
-            self.tag_mapping.get(str(tag_id), tag_id)
-            for tag_id in tag_ids
+            self.tag_mapping.get(str(tag_id), tag_id) for tag_id in tag_ids
         ]
 
     def _get_article_context(

--- a/canonicalwebteam/blog/views.py
+++ b/canonicalwebteam/blog/views.py
@@ -24,10 +24,12 @@ class BlogViews:
         feed_description=None,
         per_page=12,
         status=None,
+        tag_mapping=None,
     ):
         self.api = api
-        self.tag_ids = tag_ids
-        self.excluded_tags = excluded_tags
+        self.tag_mapping = tag_mapping
+        self.tag_ids = self._remap_tags(tag_ids)
+        self.excluded_tags = self._remap_tags(excluded_tags)
         self.blog_title = blog_title
         self.blog_path = blog_path.strip("/")
         self.feed_description = feed_description or f"{blog_title} feed"
@@ -298,6 +300,9 @@ class BlogViews:
         return feed.rss_str()
 
     def get_latest_news(self, limit=3, tag_ids=None, group_ids=None):
+        if tag_ids:
+            tag_ids = self._remap_tags(tag_ids)
+
         latest_pinned_articles, _ = self.api.get_articles(
             tags=tag_ids or self.tag_ids,
             tags_exclude=self.excluded_tags,
@@ -403,6 +408,14 @@ class BlogViews:
             "title": self.blog_title,
             "tag": tag,
         }
+
+    def _remap_tags(self, tag_ids):
+        if not self.tag_mapping:
+            return tag_ids
+        return [
+            self.tag_mapping.get(str(tag_id), tag_id)
+            for tag_id in tag_ids
+        ]
 
     def _get_article_context(
         self, article, related_tag_ids=[], excluded_tags=[]

--- a/canonicalwebteam/blog/wordpress.py
+++ b/canonicalwebteam/blog/wordpress.py
@@ -23,7 +23,7 @@ class Wordpress:
     def __init__(
         self,
         session,
-        api_url="https://admin.insights.ubuntu.com/wp-json/wp/v2",
+        api_url="https://staging-admin.insights.ubuntu.com/wp-json/wp/v2",
         wordpress_username=None,
         wordpress_password=None,
         timeout=30,


### PR DESCRIPTION
Add tag_mapping parameter to BlogViews constructor to allow remapping of tag IDs. This enables flexible tag ID translation, useful when integrating with external systems that use different tag identifiers. The mapping is applied to tag_ids, excluded_tags, and tag_ids in get_latest_news method.