### PR TITLE
feat: update BlogViews

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+7.0.0: Render pull-quote blockquotes via the vf_quote_wrapper pattern and show up to four related articles. Requires the host app to provide the `_macros/vf_quote-wrapper.jinja` template.
 6.8.4: Add request timeout (30s), retry logic for transient 5xx errors, and ChunkedEncodingError handler (502).
 6.8.3: Fix wordpress API returning 404 for article slugs containing special characters
 6.8.2: Adds a URL validity check in _apply_image_template before calling image_template(...). Skips any img with an invalid URL (non-HTTP(S) or missing host) to prevent errors from bad links.

--- a/canonicalwebteam/blog/views.py
+++ b/canonicalwebteam/blog/views.py
@@ -498,12 +498,12 @@ class BlogViews:
             )
 
         # Sort the related_articles by the most compatibility and limiting the
-        # result to the top three articles
+        # result to the top four articles
         related_articles = sorted(
             related_articles,
             key=lambda article: article["compatibility"],
             reverse=True,
-        )[:3]
+        )[:4]
 
         # Render any pull-quotes in the article body via vf_quote_wrapper.
         content = article.get("content", {})

--- a/canonicalwebteam/blog/views.py
+++ b/canonicalwebteam/blog/views.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 # Packages
 import flask
+from bs4 import BeautifulSoup
 from dateutil.relativedelta import relativedelta
 from feedgen.entry import FeedEntry
 from feedgen.feed import FeedGenerator
@@ -11,6 +12,69 @@ from feedgen.feed import FeedGenerator
 from .constants import (
     POST_DETAILS_FIELDS,
 )
+
+
+# Jinja snippet used to render a WordPress pull-quote through the
+# vf_quote_wrapper pattern. Only the quote text is used; the empty call block
+# leaves the heading, citation, CTA and image slots blank.
+QUOTE_WRAPPER_TEMPLATE = (
+    '{% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}'
+    '{% call(slot) vf_quote_wrapper('
+    'quote_size="medium", quote_text=quote_text, is_shallow=True'
+    ') %}{% endcall %}'
+)
+
+
+def convert_pull_quotes(content_html):
+    """Replace WordPress pull-quote blockquotes in article content with the
+    vf_quote_wrapper pattern.
+
+    The macro renders only the quote text; the original citation is preserved
+    (muted) below the quote. The macro is designed for full-width page
+    sections, so its content column is widened to fill the (narrower) article
+    body instead of being centred in a sub-grid.
+    """
+    if not content_html or "p-pull-quote" not in content_html:
+        return content_html
+
+    soup = BeautifulSoup(content_html, "html.parser")
+    blockquotes = soup.select('blockquote[class*="p-pull-quote"]')
+    if not blockquotes:
+        return content_html
+
+    for blockquote in blockquotes:
+        quote_el = blockquote.select_one(".p-pull-quote__quote") or blockquote
+        quote_text = quote_el.get_text(" ", strip=True)
+        if not quote_text:
+            continue
+
+        citation_el = blockquote.select_one(".p-pull-quote__citation")
+
+        fragment = BeautifulSoup(
+            flask.render_template_string(
+                QUOTE_WRAPPER_TEMPLATE, quote_text=quote_text
+            ),
+            "html.parser",
+        )
+
+        # Widen the macro's centred content column to fill the article body.
+        content_col = fragment.select_one('[class*="grid-col-start-large-3"]')
+        if content_col is not None:
+            content_col["class"] = "grid-col-12"
+            # Drop the divider rule the macro adds above the quote when there
+            # is no heading row.
+            divider = content_col.select_one("hr.p-rule--muted")
+            if divider is not None:
+                divider.decompose()
+            # Keep the original citation, muted, below the quote.
+            if citation_el is not None:
+                citation_classes = citation_el.get("class", [])
+                citation_el["class"] = citation_classes + ["u-text--muted"]
+                content_col.append(citation_el.extract())
+
+        blockquote.replace_with(fragment)
+
+    return str(soup)
 
 
 class BlogViews:
@@ -440,6 +504,11 @@ class BlogViews:
             key=lambda article: article["compatibility"],
             reverse=True,
         )[:3]
+
+        # Render any pull-quotes in the article body via vf_quote_wrapper.
+        content = article.get("content", {})
+        if content.get("rendered"):
+            content["rendered"] = convert_pull_quotes(content["rendered"])
 
         return {
             "article": article,

--- a/canonicalwebteam/blog/views.py
+++ b/canonicalwebteam/blog/views.py
@@ -13,15 +13,14 @@ from .constants import (
     POST_DETAILS_FIELDS,
 )
 
-
 # Jinja snippet used to render a WordPress pull-quote through the
 # vf_quote_wrapper pattern. Only the quote text is used; the empty call block
 # leaves the heading, citation, CTA and image slots blank.
 QUOTE_WRAPPER_TEMPLATE = (
     '{% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}'
-    '{% call(slot) vf_quote_wrapper('
+    "{% call(slot) vf_quote_wrapper("
     'quote_size="medium", quote_text=quote_text, is_shallow=True'
-    ') %}{% endcall %}'
+    ") %}{% endcall %}"
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.8.4",
+    version="7.0.0",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Done
- Updated blog to use modern quote wrapper
- Displays 4 blogs instead of 3 in related posts
- Bumped up API version.

## QA
- Visit this [demo](https://unsimilarly-shrubbiest-corene.ngrok-free.dev/blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon)
- It should match the [figma](https://www.figma.com/design/CB22O7EPgyiUQheHVpOHQ9/26.04-Blog-rebranding---Sites?node-id=1367-10912&m=dev)
- Ensure that the quote blocks on [the page](https://unsimilarly-shrubbiest-corene.ngrok-free.dev/blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon) match the figma doc
- Ensure that you see 4 blogs instead of 3 when you scroll down to the bottom of the article page

## Tickets
https://warthogs.atlassian.net/browse/WD-37146
https://warthogs.atlassian.net/browse/WD-37189