### PR TITLE
feat: site-scoped category filtering

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+7.1.0: Add site-scoped category filtering. `BlogViews` accepts an optional `category_ids` list, threaded into every article query (incl. single-article and related-article fetches) as the WordPress `categories` filter. Defaults to no filter, so existing keyword-based consumers are unaffected.
 7.0.0: Render pull-quote blockquotes via the vf_quote_wrapper pattern and show up to four related articles. Requires the host app to provide the `_macros/vf_quote-wrapper.jinja` template.
 6.8.4: Add request timeout (30s), retry logic for transient 5xx errors, and ChunkedEncodingError handler (502).
 6.8.3: Fix wordpress API returning 404 for article slugs containing special characters

--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -74,10 +74,18 @@ class BlogAPI(Wordpress):
         slug,
         tags=None,
         tags_exclude=None,
+        categories=None,
         status=None,
         fields=None,
     ):
-        article = super().get_article(slug, tags, tags_exclude, status, fields)
+        article = super().get_article(
+            slug,
+            tags=tags,
+            tags_exclude=tags_exclude,
+            categories=categories,
+            status=status,
+            fields=fields,
+        )
 
         if not article:
             return {}

--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -79,7 +79,7 @@ class BlogAPI(Wordpress):
         fields=None,
     ):
         article = super().get_article(
-            slug,
+            slug=slug,
             tags=tags,
             tags_exclude=tags_exclude,
             categories=categories,

--- a/canonicalwebteam/blog/views.py
+++ b/canonicalwebteam/blog/views.py
@@ -82,6 +82,7 @@ class BlogViews:
         api,
         tag_ids=[],
         excluded_tags=[],
+        category_ids=[],
         blog_title="Blog",
         blog_path="blog",
         feed_description=None,
@@ -91,6 +92,7 @@ class BlogViews:
         self.api = api
         self.tag_ids = tag_ids
         self.excluded_tags = excluded_tags
+        self.category_ids = category_ids
         self.blog_title = blog_title
         self.blog_path = blog_path.strip("/")
         self.feed_description = feed_description or f"{blog_title} feed"
@@ -110,6 +112,7 @@ class BlogViews:
             featured_articles, _ = self.api.get_articles(
                 tags=self.tag_ids,
                 tags_exclude=self.excluded_tags,
+                categories=self.category_ids,
                 page=page,
                 sticky="true",
                 per_page=3,
@@ -133,7 +136,7 @@ class BlogViews:
             exclude=[article["id"] for article in featured_articles],
             page=page,
             per_page=self.per_page,
-            categories=categories,
+            categories=self.category_ids + categories,
             status=self.status,
         )
 
@@ -151,6 +154,7 @@ class BlogViews:
         articles, _ = self.api.get_articles(
             tags=self.tag_ids,
             tags_exclude=self.excluded_tags,
+            categories=self.category_ids,
             fields=POST_DETAILS_FIELDS,
         )
 
@@ -171,7 +175,8 @@ class BlogViews:
             slug,
             self.tag_ids,
             self.excluded_tags,
-            self.status,
+            categories=self.category_ids,
+            status=self.status,
         )
 
         if not article:
@@ -185,6 +190,7 @@ class BlogViews:
         articles, _ = self.api.get_articles(
             tags=self.tag_ids,
             tags_exclude=self.excluded_tags,
+            categories=self.category_ids,
             page=1,
             per_page=1,
         )
@@ -198,11 +204,11 @@ class BlogViews:
 
     def get_group(self, group_slug, page=1, category_slug=None):
         group = self.api.get_group_by_slug(group_slug)
-        categories = None
+        categories = list(self.category_ids)
         category = {}
         if category_slug:
             category = self.api.get_category_by_slug(category_slug)
-            categories = [category.get("id", "")]
+            categories.append(category.get("id", ""))
 
         articles, metadata = self.api.get_articles(
             tags=self.tag_ids,
@@ -232,6 +238,7 @@ class BlogViews:
             tags=self.tag_ids,
             tags_exclude=self.excluded_tags,
             groups=[group.get("id", "")],
+            categories=self.category_ids,
             fields=POST_DETAILS_FIELDS,
         )
 
@@ -255,6 +262,7 @@ class BlogViews:
         articles, metadata = self.api.get_articles(
             tags=self.tag_ids + tag_ids,
             tags_exclude=self.excluded_tags,
+            categories=self.category_ids,
             page=page,
             per_page=self.per_page,
         )
@@ -275,6 +283,7 @@ class BlogViews:
         articles, _ = self.api.get_articles(
             tags=[tag["id"]],
             tags_exclude=self.excluded_tags,
+            categories=self.category_ids,
             fields=POST_DETAILS_FIELDS,
         )
 
@@ -320,6 +329,7 @@ class BlogViews:
         articles, metadata = self.api.get_articles(
             tags=self.tag_ids,
             tags_exclude=self.excluded_tags,
+            categories=self.category_ids,
             page=page,
             author=author["id"],
             per_page=self.per_page,
@@ -343,6 +353,7 @@ class BlogViews:
         articles, _ = self.api.get_articles(
             tags=self.tag_ids,
             tags_exclude=self.excluded_tags,
+            categories=self.category_ids,
             author=author["id"],
             fields=POST_DETAILS_FIELDS,
         )
@@ -364,6 +375,7 @@ class BlogViews:
         latest_pinned_articles, _ = self.api.get_articles(
             tags=tag_ids or self.tag_ids,
             tags_exclude=self.excluded_tags,
+            categories=self.category_ids,
             groups=group_ids,
             page=1,
             per_page=1,
@@ -373,6 +385,7 @@ class BlogViews:
         latest_articles, _ = self.api.get_articles(
             tags=tag_ids or self.tag_ids,
             tags_exclude=self.excluded_tags,
+            categories=self.category_ids,
             groups=group_ids,
             exclude=[article["id"] for article in latest_pinned_articles],
             page=1,
@@ -387,7 +400,7 @@ class BlogViews:
 
     def get_archives(self, page=1, group="", month="", year="", category=""):
         groups = []
-        categories = []
+        categories = list(self.category_ids)
 
         if group:
             group = self.api.get_group_by_slug(group)
@@ -452,6 +465,7 @@ class BlogViews:
         articles, metadata = self.api.get_articles(
             tags=[tag["id"]],
             tags_exclude=self.excluded_tags,
+            categories=self.category_ids,
             page=page,
             per_page=self.per_page,
             status=self.status,
@@ -481,6 +495,7 @@ class BlogViews:
         all_related_articles, _ = self.api.get_articles(
             tags=[tag["id"] for tag in tags],
             tags_exclude=excluded_tags,
+            categories=self.category_ids,
             per_page=10,
             exclude=[article["id"]],
         )

--- a/canonicalwebteam/blog/wordpress.py
+++ b/canonicalwebteam/blog/wordpress.py
@@ -178,6 +178,7 @@ class Wordpress:
         slug,
         tags=None,
         tags_exclude=None,
+        categories=None,
         status=None,
         fields=None,
     ):
@@ -197,6 +198,7 @@ class Wordpress:
                     "slug": sanitized_slug,
                     "tags": tags,
                     "tags_exclude": tags_exclude,
+                    "categories": categories,
                     "status": status,
                 },
                 fields=(fields if fields else POST_DETAILS_FIELDS),

--- a/canonicalwebteam/blog/wordpress.py
+++ b/canonicalwebteam/blog/wordpress.py
@@ -185,6 +185,10 @@ class Wordpress:
         """
         Get an article from Wordpress api
         :param slug: Article slug to fetch
+        :param tags: Array of tag ids to fetch the article for
+        :param tags_exclude: Array of tag ids to exclude
+        :param categories: Array of category ids the article
+            must belong to
         :param status: Array of post statuses to include
             (e.g., ['publish', 'draft'])
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.blog",
-    version="7.0.0",
+    version="7.1.0",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_category_filtering.py
+++ b/tests/test_category_filtering.py
@@ -1,0 +1,30 @@
+# Standard library
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+# Packages
+import requests
+
+# Local
+from canonicalwebteam.blog import Wordpress
+
+
+class TestWordpressGetArticleCategories(TestCase):
+    def setUp(self):
+        self.api = Wordpress(session=requests.Session())
+
+    def test_get_article_forwards_categories_param(self):
+        self.api.get_first_item = MagicMock(return_value={"slug": "x"})
+
+        self.api.get_article(slug="x", categories=[5])
+
+        params = self.api.get_first_item.call_args.args[1]
+        self.assertEqual(params["categories"], [5])
+
+    def test_get_article_categories_default_none(self):
+        self.api.get_first_item = MagicMock(return_value={"slug": "x"})
+
+        self.api.get_article(slug="x")
+
+        params = self.api.get_first_item.call_args.args[1]
+        self.assertIsNone(params["categories"])

--- a/tests/test_category_filtering.py
+++ b/tests/test_category_filtering.py
@@ -7,6 +7,7 @@ import requests
 
 # Local
 from canonicalwebteam.blog import Wordpress
+from canonicalwebteam.blog.blog_api import BlogAPI
 
 
 class TestWordpressGetArticleCategories(TestCase):
@@ -32,8 +33,6 @@ class TestWordpressGetArticleCategories(TestCase):
 
 class TestBlogAPIGetArticleCategories(TestCase):
     def test_get_article_forwards_categories_to_super(self):
-        from canonicalwebteam.blog.blog_api import BlogAPI
-
         api = BlogAPI(session=requests.Session())
 
         with patch.object(

--- a/tests/test_category_filtering.py
+++ b/tests/test_category_filtering.py
@@ -1,6 +1,6 @@
 # Standard library
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # Packages
 import requests
@@ -28,3 +28,17 @@ class TestWordpressGetArticleCategories(TestCase):
 
         params = self.api.get_first_item.call_args.args[1]
         self.assertIsNone(params["categories"])
+
+
+class TestBlogAPIGetArticleCategories(TestCase):
+    def test_get_article_forwards_categories_to_super(self):
+        from canonicalwebteam.blog.blog_api import BlogAPI
+
+        api = BlogAPI(session=requests.Session())
+
+        with patch.object(
+            Wordpress, "get_article", return_value={}
+        ) as mock_super:
+            api.get_article(slug="x", categories=[7])
+
+        self.assertEqual(mock_super.call_args.kwargs["categories"], [7])

--- a/tests/test_category_filtering.py
+++ b/tests/test_category_filtering.py
@@ -41,3 +41,47 @@ class TestBlogAPIGetArticleCategories(TestCase):
             api.get_article(slug="x", categories=[7])
 
         self.assertEqual(mock_super.call_args.kwargs["categories"], [7])
+
+
+class TestBlogViewsCategoryThreading(TestCase):
+    def _make_views(self, category_ids):
+        from canonicalwebteam.blog import BlogViews
+
+        api = MagicMock()
+        api.get_articles.return_value = (
+            [],
+            {"total_pages": "1", "total_posts": "0"},
+        )
+        api.get_article.return_value = {}
+        api.get_category_by_slug.return_value = {"id": 99}
+        return BlogViews(api=api, category_ids=category_ids), api
+
+    def test_get_index_threads_category_ids(self):
+        # page=2 skips the featured/events branch, leaving one main call
+        views, api = self._make_views([5])
+
+        views.get_index(page=2)
+
+        self.assertEqual(api.get_articles.call_args.kwargs["categories"], [5])
+
+    def test_get_index_default_category_ids_is_empty(self):
+        views, api = self._make_views([])
+
+        views.get_index(page=2)
+
+        self.assertEqual(api.get_articles.call_args.kwargs["categories"], [])
+
+    def test_get_article_threads_category_ids(self):
+        views, api = self._make_views([5])
+
+        views.get_article("some-slug")
+
+        self.assertEqual(api.get_article.call_args.kwargs["categories"], [5])
+
+    def test_get_tag_threads_category_ids(self):
+        views, api = self._make_views([5])
+        api.get_tag_by_slug.return_value = {"id": 1, "name": "Design"}
+
+        views.get_tag("design")
+
+        self.assertEqual(api.get_articles.call_args.kwargs["categories"], [5])

--- a/tests/test_category_filtering.py
+++ b/tests/test_category_filtering.py
@@ -85,3 +85,21 @@ class TestBlogViewsCategoryThreading(TestCase):
         views.get_tag("design")
 
         self.assertEqual(api.get_articles.call_args.kwargs["categories"], [5])
+
+    def test_get_group_merges_site_and_route_category_ids(self):
+        views, api = self._make_views([5])
+
+        views.get_group("my-group", category_slug="security")
+
+        categories_sent = api.get_articles.call_args.kwargs["categories"]
+        self.assertIn(5, categories_sent)
+        self.assertIn(99, categories_sent)
+
+    def test_get_archives_merges_site_and_route_category_ids(self):
+        views, api = self._make_views([5])
+
+        views.get_archives(category="security")
+
+        categories_sent = api.get_articles.call_args.kwargs["categories"]
+        self.assertIn(5, categories_sent)
+        self.assertIn(99, categories_sent)


### PR DESCRIPTION
## Done
- Add `category_ids` to `BlogViews`. Filters posts by WordPress category.
- Threaded into all article queries: list, feed, single, related.
- Add `categories` param to `get_article` (Wordpress + BlogAPI).
- Optional. Defaults to no filter. Not breaking for keyword consumers.
- Bump to 7.1.0.

## QA
- Check
  - https://github.com/canonical/jp.ubuntu.com/pull/567
    - https://jp-ubuntu-com-567.demos.haus/blog
  - https://github.com/canonical/cn.ubuntu.com/pull/865
    - https://cn-ubuntu-com-865.demos.haus/blog

## Tickets
[37012](https://warthogs.atlassian.net/browse/WD-37012)
