### PR TITLE
fix: grant release-drafter permission to publish releases

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   create-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Release Drafter has been failing to publish releases since the default `GITHUB_TOKEN` went read-only. The API call gets a 403 but the job still reports success, so nobody noticed and 7.1.0 never shipped: https://github.com/canonical/canonicalwebteam.blog/actions/runs/28586881424

This adds the `contents: write` permission the action needs, plus `pull-requests: read` for the release notes.